### PR TITLE
gotcha: Revert reasons not returned on `eth_sendRawTransaction` calls

### DIFF
--- a/src/docs/developers/integration.md
+++ b/src/docs/developers/integration.md
@@ -147,6 +147,9 @@ This will be fixed in an upcoming release.
 Make sure you're compiling with the Optimistic Ethereum version of the Solidity compiler.
 Contract deployments will usually fail if you compile using the standard Solidity compiler.
 
+#### Gotcha: Revert reasons are not returned on `eth_sendRawTransaction` calls
+When `geth` was forked for Optimistic Ethereum, the `geth` had not yet started returning revert reasons for `eth_sendRawTransaction`s. Thus, if you want to retrieve a revert reason for a failing L2 transaction on `eth_sendRawTransaction` calls, you will need to make an `eth_call` (e.g. similar to [this](https://github.com/Synthetixio/synthetix-cli/blob/165fb39ea9c4298d7193c1b7f169dfd95cc89a80/src/utils/runTx.js#L61-L72)) at the block height for that transaction. 
+
 ### Testnet Deployment
 You probably want to deploy to testnet before heading over to mainnet (good idea, tbh).
 Our primary L2 testnet is currently deployed on top of Ethereum's [Kovan](https://kovan.etherscan.io) network.

--- a/src/docs/developers/integration.md
+++ b/src/docs/developers/integration.md
@@ -148,7 +148,8 @@ Make sure you're compiling with the Optimistic Ethereum version of the Solidity 
 Contract deployments will usually fail if you compile using the standard Solidity compiler.
 
 #### Gotcha: Revert reasons are not returned on `eth_sendRawTransaction` calls
-When `geth` was forked for Optimistic Ethereum, the `geth` had not yet started returning revert reasons for `eth_sendRawTransaction`s. Thus, if you want to retrieve a revert reason for a failing L2 transaction on `eth_sendRawTransaction` calls, you will need to make an `eth_call` (e.g. similar to [this](https://github.com/Synthetixio/synthetix-cli/blob/165fb39ea9c4298d7193c1b7f169dfd95cc89a80/src/utils/runTx.js#L61-L72)) at the block height for that transaction. 
+When `geth` was forked for Optimistic Ethereum, the `geth` had not yet started returning revert reasons for `eth_sendRawTransaction`s. 
+Thus, if you want to retrieve a revert reason for a failing L2 transaction on `eth_sendRawTransaction` calls, you will need to make an `eth_call` (e.g. similar to [this](https://github.com/Synthetixio/synthetix-cli/blob/165fb39ea9c4298d7193c1b7f169dfd95cc89a80/src/utils/runTx.js#L61-L72)) at the block height for that transaction. 
 
 ### Testnet Deployment
 You probably want to deploy to testnet before heading over to mainnet (good idea, tbh).

--- a/src/docs/developers/integration.md
+++ b/src/docs/developers/integration.md
@@ -149,7 +149,7 @@ Contract deployments will usually fail if you compile using the standard Solidit
 
 #### Gotcha: Revert reasons are not returned on `eth_sendRawTransaction` calls
 When `geth` was forked for Optimistic Ethereum, the `geth` had not yet started returning revert reasons for `eth_sendRawTransaction`s. 
-Thus, if you want to retrieve a revert reason for a failing L2 transaction on `eth_sendRawTransaction` calls, you will need to make an `eth_call` (e.g. similar to [this](https://github.com/Synthetixio/synthetix-cli/blob/165fb39ea9c4298d7193c1b7f169dfd95cc89a80/src/utils/runTx.js#L61-L72)) at the block height for that transaction. 
+Thus, if you want to retrieve a revert reason for a failing L2 transaction on `eth_sendRawTransaction` calls, you will need to make an `eth_call` (e.g. similar to [this](https://github.com/Synthetixio/synthetix/blob/develop/test/optimism/utils/revertOptimism.js)) at the block height for that transaction. 
 
 ### Testnet Deployment
 You probably want to deploy to testnet before heading over to mainnet (good idea, tbh).


### PR DESCRIPTION
Fixes #36.

Note:  I used the [most recent branch](https://github.com/Synthetixio/synthetix-cli/blob/165fb39ea9c4298d7193c1b7f169dfd95cc89a80/src/utils/runTx.js#L61-L72) of Kevin's Synthetix reference:
```solidity
async function getRevertReason({ tx, provider }) {
	const code = (await provider.call(tx)).substr(138); 
	const hex = `0x${code}`;

	if (code.length === '64') {
		return ethers.utils.parseBytes32String(hex);
	} else {
		return _hexToString(hex);
	}

	return reason;
}
```