### PR TITLE
fix port assignment docs layer2 / layer1

### DIFF
--- a/src/docs/developers/integration.md
+++ b/src/docs/developers/integration.md
@@ -110,7 +110,7 @@ Then, run the famous `up.sh` script to spin everything up:
 ```
 
 And that's it!
-You now have an L2 chain (sequencer) at `localhost:9545` connected to an L1 chain at `localhost:8545`.
+You now have an L2 chain (sequencer) at `localhost:8545` connected to an L1 chain at `localhost:9545`.
 
 ### Common Gotchas
 ::: tip Need help?


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixed the documentation for the ports that are assigned to Layer 1 and Layer 2 when starting a local node.

**Additional context**
When using the https://github.com/ethereum-optimism/optimism-integration repo - and running (the famous) `./up.sh` - the documentation says that the OVM will run on `9545` and that layer 1 will run on `8545`

In actual fact - the OVM starts on `8545` and layer1 starts on `9545`
