### PR TITLE
docs: Correct discord link

### DIFF
--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -13,7 +13,7 @@ Let's make sure you know where to go next!
 
 ::: tip Heads Up
 Our documentation is a rapidly improving work in progress.
-If you have questions or feel like something is missing feel free to ask in our [Discord server](https://discord.gg/5TaAXGn2D8) where we (and our awesome community) are actively responding, or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site.
+If you have questions or feel like something is missing feel free to ask in our [Discord server](https://discord.gg/jrnFEvq) where we (and our awesome community) are actively responding, or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site.
 :::
 
 ## For: The Casually Interested Reader


### PR DESCRIPTION
**Description**
Discord link leads to an "Invalid Invite" page. This corrects the link.
