### PR TITLE
fix: replace discord links with redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Optimistic Ethereum Community Hub
 
-[![Discord](https://img.shields.io/discord/667044843901681675.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discord.com/channels/667044843901681675)
+[![Discord](https://img.shields.io/discord/667044843901681675.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discord.optimism.io)
 [![Twitter Follow](https://img.shields.io/twitter/follow/optimismPBC.svg?label=optimismPBC&style=social)](https://twitter.com/optimismPBC)
 
 Optimistic Ethereum is a Layer 2 platform for Ethereum.

--- a/src/.vuepress/components/Home.vue
+++ b/src/.vuepress/components/Home.vue
@@ -20,7 +20,7 @@
       <a class="action-button" href="/docs">read the <u>docs</u></a>
       <a class="action-button" href="https://github.com/ethereum-optimism/optimism-tutorial/blob/main/README.md">try the <u>tutorial</u></a>
       <a class="action-button" href="/faqs">check out the <u>FAQs</u></a>
-      <a class="action-button" href="https://discord.com/invite/jrnFEvq">come hang on <u>discord</u></a>
+      <a class="action-button" href="https://discord.optimism.io">come hang on <u>discord</u></a>
     </header>
   </main>
 </template>

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -46,7 +46,7 @@ module.exports = {
       },
       {
         text: 'chat',
-        link: 'https://discord.com/invite/jrnFEvq',
+        link: 'https://discord.optimism.io',
       },
     ],
     sidebar: {

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -9,7 +9,7 @@ tags:
 # {{ $frontmatter.title }}
 
 ::: tip Work in Progress™
-Our documentation is a rapidly improving work in progress. If you have questions or feel like something is missing feel free to ask in our [Discord server](https://discord.gg/5TaAXGn2D8) where we (and our awesome community) are actively responding, or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site.
+Our documentation is a rapidly improving work in progress. If you have questions or feel like something is missing feel free to ask in our [Discord server](https://discord.optimism.io) where we (and our awesome community) are actively responding, or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site.
 :::
 
 We know documentation can be a bit overwhelming sometimes, especially when the subject matter is unfamiliar.

--- a/src/docs/developers/bridging.md
+++ b/src/docs/developers/bridging.md
@@ -6,7 +6,7 @@ lang: en-US
 # {{ $frontmatter.title }}
 
 ::: tip Work in Progress™
-Our documentation is a rapidly improving work in progress. If you have questions or feel like something is missing feel free to ask in our [Discord server](https://discord.gg/5TaAXGn2D8) where we (and our awesome community) are actively responding, or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site.
+Our documentation is a rapidly improving work in progress. If you have questions or feel like something is missing feel free to ask in our [Discord server](https://discord.optimism.io) where we (and our awesome community) are actively responding, or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site.
 :::
 
 Apps on Optimistic Ethereum can be made to interact with apps on Ethereum via a process called "bridging".

--- a/src/docs/developers/integration.md
+++ b/src/docs/developers/integration.md
@@ -18,7 +18,7 @@ TODO:
 
 ## Introduction
 
-Hello and welcome! If you're looking to find out what it takes to get an app up and running on layer 2, then you've come to the right place. If at any time in this process you get stuck or have questions, please reach out on [discord](https://discord.gg/5TaAXGn2D8) and drop a message in the `#support` channel.
+Hello and welcome! If you're looking to find out what it takes to get an app up and running on layer 2, then you've come to the right place. If at any time in this process you get stuck or have questions, please reach out on [discord](https://discord.optimism.io) and drop a message in the `#support` channel.
 
 ## Overview
 
@@ -52,7 +52,7 @@ Unless...
 
 In theory, we can make the same modifications to the compilers for other langauges.
 We haven't been able to do this yet because we're a relatively small team with a lot on our plates.
-If this is something you'd like to help out with, please reach out to us on [discord](https://discord.gg/5TaAXGn2D8) and tell us!
+If this is something you'd like to help out with, please reach out to us on [discord](https://discord.optimism.io) and tell us!
 Seriously, I'm not just shilling the discord again, we'd love to help make that a reality and discord is the best way to get in touch with us.
 :::
 
@@ -133,7 +133,7 @@ Or we could pay someone to integrate it.
 Or we could even pay *you* to integrate it.
 I don't know.
 We'll figure it out.
-Point is: ping us on [discord](https://discord.gg/5TaAXGn2D8) and let us know how we can help.
+Point is: ping us on [discord](https://discord.optimism.io) and let us know how we can help.
 :::
 
 ## Testing Contracts

--- a/src/docs/protocol/protocol.md
+++ b/src/docs/protocol/protocol.md
@@ -31,7 +31,7 @@ These are some great documentation sites for inspiration:
 -->
 
 ::: tip Work in Progress™
-_Our documentation is a rapidly improving work in progress. If you have questions or feel like something is missing feel free to ask in our [Discord server](https://discord.gg/5TaAXGn2D8) where we (and our awesome community) are actively responding, or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site._
+_Our documentation is a rapidly improving work in progress. If you have questions or feel like something is missing feel free to ask in our [Discord server](https://discord.optimism.io) where we (and our awesome community) are actively responding, or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site._
 :::
 
 ## Introduction

--- a/src/docs/resources/general-resources.md
+++ b/src/docs/resources/general-resources.md
@@ -11,7 +11,7 @@ tags:
 ::: tip Are we missing something? 🧐
 Want your content featured on this page?
 Think we don't have enough information about a certain topic?
-Hop on the [discord](https://discord.gg/5TaAXGn2D8) and make a post in `#resources` or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site. ✨
+Hop on the [discord](https://discord.optimism.io) and make a post in `#resources` or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site. ✨
 :::
 
 ## [*Mainnet Soft Launch*](https://medium.com/ethereum-optimism/mainnet-soft-launch-7cacc0143cd5)

--- a/src/docs/resources/protocol-readings.md
+++ b/src/docs/resources/protocol-readings.md
@@ -11,7 +11,7 @@ tags:
 ::: tip Are we missing something? 🧐
 Want your content featured on this page?
 Think we don't have enough information about a certain topic?
-Hop on the [discord](https://discord.gg/5TaAXGn2D8) and make a post in `#resources` or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site. ✨
+Hop on the [discord](https://discord.optimism.io) and make a post in `#resources` or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site. ✨
 :::
 
 ## [*OVM Deep Dive*](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)

--- a/src/docs/resources/talks.md
+++ b/src/docs/resources/talks.md
@@ -11,7 +11,7 @@ tags:
 ::: tip Are we missing something? 🧐
 Want your content featured on this page?
 Think we don't have enough information about a certain topic?
-Hop on the [discord](https://discord.gg/5TaAXGn2D8) and make a post in `#resources` or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site. ✨
+Hop on the [discord](https://discord.optimism.io) and make a post in `#resources` or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site. ✨
 :::
 
 ## [*Optimism 🛠 Overview & Code Walkthrough*](https://www.youtube.com/watch?v=AHYSZ51ATWQ)

--- a/src/docs/resources/tooling.md
+++ b/src/docs/resources/tooling.md
@@ -11,7 +11,7 @@ tags:
 ::: tip Are we missing something? 🧐
 Want your content featured on this page?
 Think we don't have enough information about a certain topic?
-Hop on the [discord](https://discord.gg/5TaAXGn2D8) and make a post in `#resources` or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site. ✨
+Hop on the [discord](https://discord.optimism.io) and make a post in `#resources` or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site. ✨
 :::
 
 ## [@eth-optimism/hardhat-ovm](https://github.com/ethereum-optimism/optimism/tree/master/packages/hardhat-ovm)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Replaces old discord links with a link to https://discord.optimism.io (which will now be our permanent redirect).

**Metadata**
- Fixes #114 
