### PR TITLE
Add 'about' field to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issues.md
+++ b/.github/ISSUE_TEMPLATE/issues.md
@@ -1,5 +1,6 @@
 ---
 name: Documentation Issue
+about: Report incorrect or missing information from https://community.optimism.io/
 
 ---
 


### PR DESCRIPTION
Fixes the likely reason why the new issue template isn't applying.