### PR TITLE
20210923 changes

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -108,6 +108,7 @@ module.exports = {
                 '/docs/developers/l2/contracts-2.0.md',                
                 '/docs/developers/l2/block-time.md',
                 '/docs/developers/l2/rpc.md',
+                '/docs/developers/l2/rpc-2.0.md',                
               ],
               collapsable: false,
               sidebarDepth: 0,

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -42,7 +42,8 @@ module.exports = {
             '/docs/users/metamask.md',
             '/docs/users/gateway.md',
             '/docs/users/apps.md',
-            '/docs/users/fees.md'
+            '/docs/users/fees.md',
+            '/docs/users/fees-2.0.md',            
           ],
           collapsable: false,
           sidebarDepth: 0,
@@ -104,6 +105,7 @@ module.exports = {
                 '/docs/developers/l2/new-fees.md',
                 '/docs/developers/l2/future.md',
                 '/docs/developers/l2/contracts.md',
+                '/docs/developers/l2/contracts-2.0.md',                
                 '/docs/developers/l2/block-time.md',
                 '/docs/developers/l2/rpc.md',
               ],
@@ -146,6 +148,7 @@ module.exports = {
           title: 'Protocol Specs',
           children: [
             '/docs/protocol/protocol.md',
+            '/docs/protocol/protocol-2.0.md',            
             '/docs/protocol/evm-comparison.md',
             '/docs/protocol/protocol-readings.md',
           ],

--- a/src/docs/developers/bridge/messaging.md
+++ b/src/docs/developers/bridge/messaging.md
@@ -5,6 +5,13 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
+
 Apps on Optimistic Ethereum can be made to interact with apps on Ethereum via a process called "bridging".
 In a nutshell, **contracts on Optimistic Ethereum can send messages to contracts on Ethereum, and vice versa**.
 With just a little bit of elbow grease, you too can create contracts that bridge the gap between Layer 1 and Layer 2!

--- a/src/docs/developers/bridge/standard-bridge.md
+++ b/src/docs/developers/bridge/standard-bridge.md
@@ -50,7 +50,7 @@ Optimism provides a standard implementation of that interface as the [`L2Standar
 
 If the `L2StandardERC20` implementation does not satisfy your requirements, you can deploy an alternative implementation as long as it's compliant with the `IL2StandardERC20` interface.
 You can freely deploy your proposed implementation to the Optimistic Kovan testnet.
-Once you're ready with a tested kovan deployment, you can request a review via [this](https://docs.google.com/forms/d/e/1FAIpQLSdKyXpXY1C4caWD3baQBK1dPjEboOJ9dpj9flc-ursqq8KU0w/viewform) form and we'll consider whitelisting your deployer address on the Optimistic Ethereum mainnet.
+Once you're ready with a tested kovan deployment, you can request a review via [this](https://docs.google.com/forms/d/e/1FAIpQLSfBGsJN3nZQRLdMjqCS_svfQoPkn35o_cc4HUVnLlXN2BHmPw/viewform) form and we'll consider whitelisting your deployer address on the Optimistic Ethereum mainnet.
 This condition only remains as long as the Optimistic Ethereum mainnet has a whitelist.
 
 ## The Optimism token list

--- a/src/docs/developers/bridge/standard-bridge.md
+++ b/src/docs/developers/bridge/standard-bridge.md
@@ -5,6 +5,12 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
 Certain interactions, like transferring ETH and ERC20 tokens between the two networks, are common enough that we've built the "Standard Bridge" to make moving these assets betwen L1 and L2 as easy as possible.
 The Standard Bridge is composed of two main contracts the [`OVM_L1StandardBridge`](https://github.com/ethereum-optimism/optimism/blob/master/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1StandardBridge.sol) (for Layer 1) and the [`OVM_L2StandardBridge`](https://github.com/ethereum-optimism/optimism/blob/master/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2StandardBridge.sol) (for Layer 2).
 Here we'll go over the basics of using this bridge to move ERC20 assets between Layer 1 and Layer 2.

--- a/src/docs/developers/fees.md
+++ b/src/docs/developers/fees.md
@@ -5,8 +5,10 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
-::: warning NOTICE
-This page documents the current status of the Optimistic Ethereum protocol, and the details here are subject to change based on feedback.
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
 :::
 
 Optimistic Ethereum is a lot cheaper than regular Ethereum but transaction fees do still exist.

--- a/src/docs/developers/l2/block-time.md
+++ b/src/docs/developers/l2/block-time.md
@@ -5,6 +5,12 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
 Block numbers and timestamps in Optimistic Ethereum are similar, but not entirely identical, to those in Ethereum.
 
 ## Block numbers

--- a/src/docs/developers/l2/changeset.md
+++ b/src/docs/developers/l2/changeset.md
@@ -52,15 +52,16 @@ During the next regenesis (Early October on Kovan, End of October on the main ne
 1. Certain opcodes will have updated functionality:
     1. `NUMBER` - `block.number` in L2 will now correspond to the L2 
        block number, not “Last finalized L1 block number” like it used to. Any project currently using `block.number` must check that this will not break their implementation. The L1 Block number will be made accessible via a new predeployed contract.
-    2. `COINBASE` is set by the sequencer. For the near-term future, 
+    1. `COINBASE` is set by the sequencer. For the near-term future, 
        it will return the `OVM_SequencerFeeVault` address (currently `0x4200000000000000000000000000000000000011`)
-    3. `DIFFICULTY` will return 0
-    4. `BLOCKHASH` will return the L2 block hash. Note that this value 
+    1. `DIFFICULTY` will return 0
+    1. `BLOCKHASH` will return the L2 block hash. Note that this value 
        can be manipulated by the sequencer and is not a safe source of randomness.
-    5. `SELFDESTRUCT` will now work just as it currently works in the EVM.
-    6. `GASPRICE` will now return the l2GasPrice
-    7. `BASEFEE` will be unsupported - execution will revert if it is 
+    1. `SELFDESTRUCT` will now work just as it currently works in the EVM.
+    1. `GASPRICE` will now return the l2GasPrice
+    1. `BASEFEE` will be unsupported - execution will revert if it is 
        used.
+    1. `ORIGIN` will be supported normally.
 8. Certain OVM system contracts will be wiped from the state. We will remove:
     1.  `OVM_ExecutionManager`
     2.  `OVM_SequencerEntrypoint`

--- a/src/docs/developers/l2/contracts-2.0.md
+++ b/src/docs/developers/l2/contracts-2.0.md
@@ -1,26 +1,26 @@
 ---
-title: Using the Protocol Contracts in OVM 1.0
+title: Using the Protocol Contracts in OVM 2.0
 lang: en-US
 ---
 
 # {{ $frontmatter.title }}
 
-::: danger OVM 1.0 Page
-This page refers to the **current** state of the Optimistic Ethereum
-network. Some of the information may be relevant to OVM 2.0, which will
-be deployed in October, but some of it may change.
+::: warning OVM 2.0 Page
+This page refers to the **new** state of Optimistic Ethereum after the
+OVM 2.0 update. We expect to deploy OVM 2.0 mid October on the Kovan
+test network and by the end of October on the production network.
 :::
 
 ## Finding contract addresses
 
 Check out the [Networks and Connection Details page](/docs/infra/networks.md) for links to the contract addresses for each network.
 You can also find the addresses for all networks in the [`deployments` folder](https://github.com/ethereum-optimism/optimism/tree/master/packages/contracts/deployments) of the [`contracts` package](https://github.com/ethereum-optimism/optimism/tree/master/packages/contracts).
-Take a look at the [Contract Overview](/docs/protocol/protocol.md) for a list of all protocol contracts and their purpose within the system.
+Take a look at the [Contract Overview](/docs/protocol/protocol-2.0.md) for a list of all protocol contracts and their purpose within the system.
 
 ## [@eth-optimism/contracts](https://github.com/ethereum-optimism/optimism/tree/master/packages/contracts)
 
 The easiest way to interact with the Optimistic Ethereum protocol contracts is to use the [@eth-optimism/contracts](https://github.com/ethereum-optimism/optimism/tree/master/packages/contracts) npm package.
-You can use this package to get an interface or factory instance for any of the OE contracts.
+You can use this package to get an interface or factory instance for any of the Optimistic Ethereum contracts.
 
 ### Installation
 
@@ -41,7 +41,7 @@ Here are some of the most useful tools exported by the package:
 const { getContractInterface } = require("@eth-optimism/contracts");
 
 // Returns an ethers.utils.Interface object
-const iface = getContractInterface("OVM_CanonicalTransactionChain"); // or whatever contract
+const iface = getContractInterface("CanonicalTransactionChain"); // or whatever contract
 ```
 
 #### `getContractFactory`
@@ -50,7 +50,7 @@ const iface = getContractInterface("OVM_CanonicalTransactionChain"); // or whate
 const { getContractFactory } = require("@eth-optimism/contracts");
 
 // Returns an ethers.ContractFactory object
-const factory = getContractFactory("OVM_CanonicalTransactionChain"); // or whatever contract
+const factory = getContractFactory("CanonicalTransactionChain"); // or whatever contract
 ```
 
 #### `getL1ContractData`
@@ -59,7 +59,7 @@ const factory = getContractFactory("OVM_CanonicalTransactionChain"); // or whate
 const { getL1ContractData } = require("@eth-optimism/contracts");
 
 // Returns an ethers.Contract object at the correct address
-const contract = getL1ContractData("mainnet").OVM_CanonicalTransactionChain; // or whatever contract
+const contract = getL1ContractData("mainnet").CanonicalTransactionChain; // or whatever contract
 ```
 
 #### `getL2ContractData`
@@ -68,7 +68,7 @@ const contract = getL1ContractData("mainnet").OVM_CanonicalTransactionChain; // 
 const { getL2ContractData } = require("@eth-optimism/contracts");
 
 // Returns an ethers.Contract object at the correct address
-const contract = getL2ContractData().OVM_ETH; // or whatever contract
+const contract = getL2ContractData().L2StandardBridge; // or whatever contract
 ```
 
 #### `predeploys`
@@ -77,5 +77,5 @@ const contract = getL2ContractData().OVM_ETH; // or whatever contract
 const { predeploys } = require("@eth-optimism/contracts");
 
 // Returns an address (string)
-const ovmETHAddress = predeploys.OVM_ETH; // or whatever contract
+const ovmETHAddress = predeploys.OVM_GasPriceOracle; // or whatever contract
 ```

--- a/src/docs/developers/l2/contracts.md
+++ b/src/docs/developers/l2/contracts.md
@@ -5,6 +5,12 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
 ## Finding contract addresses
 
 Check out the [Networks and Connection Details page](/docs/infra/networks.md) for links to the contract addresses for each network.

--- a/src/docs/developers/l2/convert.md
+++ b/src/docs/developers/l2/convert.md
@@ -92,7 +92,7 @@ Ethereum:
    environment.
 1. Upload and verify the contracts' source code on [Optimistic Kovan 
    Etherscan](https://kovan-optimistic.etherscan.io/verifyContract) 
-1. [Ask to be added to the Optimistic Ethereum whitelist](https://docs.google.com/forms/d/e/1FAIpQLSdKyXpXY1C4caWD3baQBK1dPjEboOJ9dpj9flc-ursqq8KU0w/viewform)    
+1. [Ask to be added to the Optimistic Ethereum whitelist](https://docs.google.com/forms/d/e/1FAIpQLSfBGsJN3nZQRLdMjqCS_svfQoPkn35o_cc4HUVnLlXN2BHmPw/viewform)    
 1. Once added, deploy your contracts to the 
    [Optimistic Ethereum](/docs/infra/networks.html#optimistic-ethereum) network. Then, upload and 
    verify your contracts' source code on [Optimistic Etherscan](https://optimistic.etherscan.io/verifyContract).

--- a/src/docs/developers/l2/convert.md
+++ b/src/docs/developers/l2/convert.md
@@ -5,9 +5,10 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
-::: warning NOTICE
-This page refers to the design of the current iteration of the Optimistic Ethereum protocol.
-Details here are subject to change as the Optimistic Ethereum protocol evolves.
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
 :::
 
 

--- a/src/docs/developers/l2/deploy.md
+++ b/src/docs/developers/l2/deploy.md
@@ -23,7 +23,7 @@ We currently require addresses to be whitelisted before they can deploy onto the
 1. Carefully check through [the list of potentially breaking changes of the next upgrade](/docs/developers/l2/changeset.html) and ensure your contracts will not be affected
 2. Deploy your contracts to our Optimistic Kovan test network
 3. Verify each of these contracts on Optimistic Kovan Etherscan*
-4. Fill out the Whitelist application form
+4. Fill out [the Whitelist application form](https://docs.google.com/forms/d/e/1FAIpQLSfBGsJN3nZQRLdMjqCS_svfQoPkn35o_cc4HUVnLlXN2BHmPw/viewform)
 5. After the next Kovan regenesis, you must confirm that your Kovan deployment has remained fully functional
 
 If you are whitelisted and deploy to Mainnet, you must:

--- a/src/docs/developers/l2/dev-node.md
+++ b/src/docs/developers/l2/dev-node.md
@@ -5,6 +5,14 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
+
+
 ::: tip
 You can [check out one of the getting started tutorials](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/hardhat) for a step-by-step guide to using a development node.
 You can also find some more detailed information about working with the development node on the [Optimism monorepo](https://github.com/ethereum-optimism/optimism#development-quick-start).

--- a/src/docs/developers/l2/hardhat.md
+++ b/src/docs/developers/l2/hardhat.md
@@ -5,6 +5,12 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
 ::: tip
 For more detailed step by step instructions [check out the hardhat tutorial](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/hardhat).
 :::

--- a/src/docs/developers/l2/new-fees.md
+++ b/src/docs/developers/l2/new-fees.md
@@ -5,6 +5,12 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
+::: warning OVM 2.0 Page
+This page refers to the **new** state of Optimistic Ethereum after the
+OVM 2.0 update. We expect to deploy OVM 2.0 mid October on the Kovan
+test network and by the end of October on the production network.
+:::
+
 ## For Users:
 
 - We recommend not changing your transaction gasPrice from what is quoted to you. Unlike on L1 Ethereum, the sequencer currently either immediately accepts your transaction if it pays a high enough gasPrice or rejects it if the gasPrice provided is too low.

--- a/src/docs/developers/l2/new-fees.md
+++ b/src/docs/developers/l2/new-fees.md
@@ -36,6 +36,9 @@ const input = WETH.populateTransaction.transfer(to, amount)
 //TODO ensure input includes a signature and is full RLP-encoded tx
 // probably fill in all 0xff for the signature
 const l1FeeInWei = await OVM_GasPriceOracle.getL1Fee(input)
+
+
+
 ```
 
 - You should *not* allow users to change their `tx.gasPrice`

--- a/src/docs/developers/l2/new-fees.md
+++ b/src/docs/developers/l2/new-fees.md
@@ -32,10 +32,16 @@ import { ethers } from 'ethers'
 const OVM_GasPriceOracle = getContractFactory('OVM_GasPriceOracle')
 .attach(predeploys.OVM_GasPriceOracle)
 const WETH = new Contract(...) //Contract with no signer
-const input = WETH.populateTransaction.transfer(to, amount)
-//TODO ensure input includes a signature and is full RLP-encoded tx
-// probably fill in all 0xff for the signature
-const l1FeeInWei = await OVM_GasPriceOracle.getL1Fee(input)
+const unsignedTx = WETH.populateTransaction.transfer(to, amount)
+const signedTx = serialize({
+      nonce: parseInt(unsignedTx.nonce.toString(10), 10),
+      value: unsignedTx.value,
+      gasPrice: unsignedTx.gasPrice,
+      gasLimit: unsignedTx.gasLimit,
+      to: unsignedTx.to,
+      data: unsignedTx.data,
+    })
+const l1FeeInWei = await OVM_GasPriceOracle.getL1Fee(signedTx)
 
 
 

--- a/src/docs/developers/l2/rpc-2.0.md
+++ b/src/docs/developers/l2/rpc-2.0.md
@@ -1,14 +1,14 @@
 ---
-title: JSON-RPC API Differences in OVM 1.0
+title: JSON-RPC API Differences in OVM 2.0
 lang: en-US
 ---
 
 # {{ $frontmatter.title }}
 
-::: danger OVM 1.0 Page
-This page refers to the **current** state of the Optimistic Ethereum
-network. Some of the information may be relevant to OVM 2.0, which will
-be deployed in October, but some of it may change.
+::: warning OVM 2.0 Page
+This page refers to the **new** state of Optimistic Ethereum after the
+OVM 2.0 update. We expect to deploy OVM 2.0 mid October on the Kovan
+test network and by the end of October on the production network.
 :::
 
 Most JSON-RPC methods in Optimistic Ethereum are identical to the corresponding methods in the Ethereum JSON-RPC API.
@@ -18,8 +18,8 @@ However, a few JSON-RPC methods have been added or changed to better fit the nee
 
 ### `eth_estimateGas`
 
-`eth_estimateGas` has been modified to encode information about both the cost of _executing_ a transaction and the cost to _publish_ the transaction data to Layer 1 (Ethereum).
-See our dedicated [Transaction Fees page](docs/infra/fees.html) for more information.
+`eth_estimateGas` only returns information about the L2 execution fee. 
+See our [transaction fees page](new-fees.html) for more information.
 
 ### `eth_getBlockByNumber` and `eth_getBlockByHash`
 
@@ -33,11 +33,6 @@ Note that this increases the number of blocks produced by the network, which may
 Our custom JSON-RPC methods are highly subject to change.
 We generally do not recommend relying on these JSON-RPC methods for the moment.
 :::
-
-### `eth_estimateExecutionGas`
-
-Behaves identically to `eth_estimateGas` on a standard L1 node.
-Returns the expected _execution_ gas cost of a transaction and does not include any information about the cost to publish the transaction data to Layer 1.
 
 ### `eth_getBlockRange`
 
@@ -58,6 +53,7 @@ Like `eth_getBlockByNumber` but accepts a range of block numbers instead of just
 **Returns**
 
 An array of blocks (see [eth_getBlockByHash](https://eth.wiki/json-rpc/API#eth_getblockbyhash)).
+
 
 ### `rollup_getInfo`
 

--- a/src/docs/developers/l2/rpc.md
+++ b/src/docs/developers/l2/rpc.md
@@ -5,6 +5,12 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
 Most JSON-RPC methods in Optimistic Ethereum are identical to the corresponding methods in the Ethereum JSON-RPC API.
 However, a few JSON-RPC methods have been added or changed to better fit the needs of Optimistic Ethereum.
 

--- a/src/docs/developers/l2/truffle.md
+++ b/src/docs/developers/l2/truffle.md
@@ -5,6 +5,11 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
 
 ::: warning
 There is an [open issue](https://github.com/ethereum-optimism/optimism/issues/1081) that could cause a problem when following these directions.

--- a/src/docs/developers/util.md
+++ b/src/docs/developers/util.md
@@ -5,6 +5,12 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
 These are contracts that are expected to be useful for multiple projects.
 
 

--- a/src/docs/infra/networks.md
+++ b/src/docs/infra/networks.md
@@ -34,7 +34,7 @@ we will open it up to anybody who wants to deploy, but we need to do more develo
 and testing before we get there. 99.9% secure is not good enough.
 
 When you are ready to deploy to production please fill up 
-[this form](https://docs.google.com/forms/d/e/1FAIpQLSdKyXpXY1C4caWD3baQBK1dPjEboOJ9dpj9flc-ursqq8KU0w/viewform) 
+[this form](https://docs.google.com/forms/d/e/1FAIpQLSfBGsJN3nZQRLdMjqCS_svfQoPkn35o_cc4HUVnLlXN2BHmPw/viewform) 
 and we'll get back to you.
 :::
 

--- a/src/docs/infra/networks.md
+++ b/src/docs/infra/networks.md
@@ -5,6 +5,12 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
 ## Optimistic Kovan
 
 ::: tip Purpose

--- a/src/docs/infra/third-party-tools.md
+++ b/src/docs/infra/third-party-tools.md
@@ -5,6 +5,12 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
 <!-- TODO: add a section for remix once we have a tutorial for using the remix plugin -->
 
 ---

--- a/src/docs/protocol/evm-comparison.md
+++ b/src/docs/protocol/evm-comparison.md
@@ -8,6 +8,12 @@ tags:
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
 For the most part, the EVM and the OVM are pretty much identical.
 However, the OVM *does* slightly diverge from the EVM in certain ways.
 This page acts as a living record of each of these discrepancies and their raison d'être.

--- a/src/docs/protocol/protocol-2.0.md
+++ b/src/docs/protocol/protocol-2.0.md
@@ -1,0 +1,232 @@
+---
+title: Contract Overview for OVM 2.0
+lang: en-US
+tags:
+    - contracts
+    - high-level
+---
+
+# {{ $frontmatter.title }}
+
+::: warning OVM 2.0 Page
+This page refers to the **new** state of Optimistic Ethereum after the
+OVM 2.0 update. We expect to deploy OVM 2.0 mid October on the Kovan
+test network and by the end of October on the production network.
+:::
+
+
+## Introduction
+
+<!-- - Welcome!  Give context -- "how to read these docs" -->
+
+Optimistic Ethereum (OE) is a Layer 2 scaling protocol for Ethereum applications.
+I.e., it makes transactions cheap. Real cheap.
+We aim to make transacting on Ethereum affordable and
+accessible to anyone.
+
+This document is intended for anyone looking for a deeper understanding of how the protocol works
+'under the hood'.
+If you just want to skip straight to integrating your smart contract application with
+OE, check out the [Developer Docs](/docs/developers/l2/convert.html).
+
+Optimistic Ethereum is meant to look, feel and behave like Ethereum but cheaper and faster.
+For developers building on our OE, we aim to make the transition as seamless as possible.
+With very few exceptions,
+existing Solidity smart contracts can run on L2 exactly how they run on L1.
+Similarly, off-chain code (ie. UIs and wallets), should be able to interact with L2 contract with little more than an updated RPC endpoint.
+
+
+## System Overview
+
+The smart contracts in the Optimistic Ethereum (OE) protocol can be separated into a few key components. We will discuss each component in more detail below.
+
+- **[Chain:](#chain-contracts)** Contracts on layer-1, which hold the ordering of layer-2 transactions, and commitments to the associated layer-2 state roots.
+- **[Verification:](#verification)** Contracts on layer-1 which implement the process for challenging a transaction result.
+- **[Bridge:](#bridge-contracts)** Contracts which facilitate message passing between layer-1 and layer-2.
+- **[Predeploys:](#predeployed-contracts)** A set of essential contracts which are deployed and available in the genesis state of the system. These contracts are similar to Ethereum's precompiles, however they are written in Solidity, and can be found at addresses prefixed with 0x42.
+
+
+<!-- Using html instead of markdown so we can put a caption on the image. -->
+<figure>
+  <img src='../../assets/docs/protocol/oe-arch-rc0.png'>
+  <figcaption style="text-align: center; font-size: 12px;">Diagram created with <a href="https://www.diagrams.net/">draw.io</a>. <br>Editable source <a href="https://docs.google.com/document/d/1OObmIhuVyh5GEekqT4dd3bzO58ejSQb_rlnrBmxcNN0/edit#">here</a>.</figcaption>
+</figure>
+
+<!--
+ - Contracts Reference Sheet (aka glossary)
+  - Deployed contracts (with addresses ie. [aave example][aave])
+-->
+
+## Chain Contracts
+
+The Chain is composed of a set of contracts running on the Ethereum mainnet. These contracts store ordered
+lists of:
+
+1. An _ordered_ list of all transactions applied to the L2 state.
+2. The proposed state root which would results from the application of each transaction.
+3. Transactions sent from L1 to L2, which are pending inclusion in the ordered list.
+
+<!--
+**Planned section outline**
+- Delineation between CTC and SCC,
+- **high priority**: explain once and for all that challenges roll back state roots, but NOT transactions
+- Diagram of "the chains" and what is stored on chain -- ideally illustrates the "roll up" mechanism whereby only roots of batches are SSTOREd
+- Sequencing -- what are the properties, what are the implications
+- Ring buffer?? (lean deprioritize)
+-->
+
+The chain is composed of the following concrete contracts:
+<!-- [concrete contracts][stackex]: -->
+
+### [`CanonicalTransactionChain`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L1/rollup/CanonicalTransactionChain.sol) (CTC)
+
+The Canonical Transaction Chain (CTC) contract is an append-only log of transactions which must be applied to the OVM state. It defines the ordering of transactions by writing them to the `CTC:batches` instance of the Chain Storage Container. The CTC also allows any account to `enqueue()` an L2 transaction, which the Sequencer must  eventually append to the rollup state.
+
+### [`StateCommitmentChain`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L1/rollup/StateCommitmentChain.sol) (SCC)
+
+The State Commitment Chain (SCC) contract contains a list of proposed state roots which Proposers assert to be a result of each transaction in the Canonical Transaction Chain (CTC). Elements here have a 1:1 correspondence with transactions in the CTC, and should be the unique state root calculated off-chain by applying the canonical transactions one by one.
+
+### [`ChainStorageContainer`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L1/rollup/ChainStorageContainer.sol)
+
+Provides reusable storage in the form of a "Ring Buffer" data structure, which will overwrite storage slots that are no longer needed. There are three Chain Storage Containers deployed, two are controlled by the CTC, one by the SCC.
+
+<!-- [stackex]: TODO - create a stackexchange Q and A, to make this term real. -->
+
+## Verification
+
+In the previous section, we mentioned that the Chain includes a list of the _proposed_ state roots
+resulting from each transaction. Here we explain a bit more about how these proposals happen, and how
+we come to trust them.
+
+In brief: If a proposed state root is not the correct result of executing a transaction, then a Verifier (which is anyone running an OE 'full node') can initiate a transaction result challenge. If the transaction result is successfully proven to be incorrect, the Verifier will receive a reward taken from funds which a Sequencer must put up as a bond.
+
+::: Notice
+This system is still being written, so these details are likely to
+change
+:::
+
+
+
+### [`BondManager`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L1/verification/BondManager.sol)
+The Bond Manager contract handles deposits in the form of an ERC20 token from bonded Proposers. It also handles the accounting of gas costs spent by a Verifier during the course of a challenge. In the event of a successful challenge, the faulty Proposer's bond is slashed, and the Verifier's gas costs are refunded.
+
+
+
+## Bridge Contracts
+
+The Bridge contracts implement the functionality required to pass messages between layer 1 and layer 2.  [You can read an overview
+here](/docs/developers/bridge/messaging.html)
+
+<!--
+**Planned section outline**
+- Low-level tools (ovmL1TXORIGIN, state committment access)
+
+### Key concepts
+- **Relaying** refers to executing a message sent from the other domain, ie. "this message was relayed
+-->
+
+The Bridge is composed of the following concrete contracts:
+
+### [`L1CrossDomainMessenger`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol)
+The L1 Cross Domain Messenger (L1xDM) contract sends messages from L1 to L2, and relays messages from L2 onto L1. In the event that a message sent from L1 to L2 is rejected for exceeding the L2 epoch gas limit, it can be resubmitted via this contract's replay function.
+
+### [`L2CrossDomainMessenger`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L2/messaging/L2CrossDomainMessenger.sol)
+The L2 Cross Domain Messenger (L2xDM) contract sends messages from L2 to L1, and is the entry point for L2 messages sent via the L1 Cross Domain Messenger.
+
+
+## The Standard Bridge
+
+One common case of message passing is "transferring" either ERC-20
+tokens or ETH between L1 and Optimistic Ethereum. To deposit tokens 
+into Optimistic Ethereum, the bridge locks them on L1 and mints equivalent
+tokens in Optimistic Ethereum. To withdraw tokens, the bridge burns the 
+Optimistic Ethereum tokens and releases the locked L1 tokens. [More details
+are here](/docs/developers/bridge/standard-bridge.html)
+
+
+### [`L1StandardBridge`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol)
+The L1 part of the Standard Bridge. Responsible for finalising withdrawals from L2 and initiating deposits into L2 of ETH and compliant ERC20s.
+
+
+### [`L2StandardBridge`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L2/messaging/L2StandardBridge.sol)
+The L2 part of the Standard Bridge. Responsible for finalising deposits from L1 and initiating withdrawals from L2 of ETH and compliant ERC20s.
+
+### [`L2StandardTokenFactory`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L2/messaging/L2StandardTokenFactory.sol)
+
+Factory contract for creating standard L2 token representations of L1 ERC20s compatible with and working on the standard bridge. 
+[See here for more information](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/standard-bridge-standard-token).
+
+
+## Predeployed Contracts
+
+"Predeploys" are a set of essential L2 contracts which are deployed and available in the genesis state of the system. These contracts are similar to Ethereum's precompiles, however they are written in Solidity and can be found in the OVM at addresses prefixed with 0x42.
+
+Looking up predeploys is available in the Solidity library [`Lib_PredeployAddresses`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/libraries/constants/Lib_PredeployAddresses.sol) as well as in the `@eth-optimism/contracts` package as `predeploys` export.
+
+The following concrete contracts are predeployed:
+
+### [`OVM_DeployerWhitelist`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L2/predeploys/OVM_DeployerWhitelist.sol)
+The Deployer Whitelist is a temporary predeploy used to provide additional safety during the initial phases of our mainnet roll out. It is owned by the Optimism team, and defines accounts which are allowed to deploy contracts on Layer 2. The Execution Manager will only allow a `CREATE` or `CREATE2` operation to proceed if the deployer's address whitelisted.
+
+<!--
+### [`OVM_L1MessageSender`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_L1MessageSender.sol)
+The L1MessageSender is a predeployed contract running on L2.
+During the execution of cross domain transaction from L1 to L2, it returns the address of the L1 account (either an EOA or contract) which sent the message to L2 via the Canonical Transaction Chain's `enqueue()` function.
+This contract exclusively serves as a getter for the `ovmL1TXORIGIN` operation.
+This is necessary because there is no corresponding EVM opcode which the optimistic solidity compiler could replace with a call to the ExecutionManager's `ovmL1TXORIGIN()` function.
+That is, if a contract on L2 wants to know which L1 address initiated a call on L2, the way to do it is by calling `OVM_L1MessageSender.ovmL1TXORIGIN()`.
+-->
+
+### [`OVM_L2ToL1MessagePasser`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L2/predeploys/OVM_L2ToL1MessagePasser.sol)
+The L2 to L1 Message Passer is a utility contract which facilitate an L1 proof of the  of a message on L2. The L1 Cross Domain Messenger performs this proof in its _verifyStorageProof function, which verifies the existence of the transaction hash in this  contract's `sentMessages` mapping.
+
+<!--
+### [`OVM_SequencerEntrypoint`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol)
+The Sequencer Entrypoint is a predeploy which, despite its name, can in fact be called by  any account. It accepts a more efficient compressed calldata format, which it decompresses and  encodes to the standard EIP155 transaction format. This contract is the implementation referenced by the Proxy Sequencer Entrypoint, thus enabling the Optimism team to upgrade the decompression of calldata from the Sequencer.
+--> 
+
+### [`OVM_SequencerFeeVault`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L2/predeploys/OVM_SequencerFeeVault.sol)
+This contract holds fees paid to the sequencer until there is enough to 
+justify the transaction cost of sending them to L1 where they are used to
+pay for L1 transaction costs (mostly the cost of publishing all L2 transaction
+data as CALLDATA on L1).
+
+<!-- we already have this above
+
+### [`OVM_L2StandardBridge`](https://github.com/ethereum-optimism/optimism/blob/master/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2StandardBridge.sol)
+The L2 part of the Standard Bridge. Responsible for finalising deposits from L1 and initiating withdrawals from L2 of ETH and compliant ERC20s.
+See [Standard Bridge](/docs/developers/bridge/standard-bridge.html) for details.
+-->
+
+<!--
+### [`OVM_ExecutionManagerWrapper`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_ExecutionManagerWrapper.sol)
+This is the one contract on L2 that can call another contract without having to
+go through virtualization. It is used to call 
+[OVM_ExecutionManager](#ovm-executionmanager).
+-->
+
+<!--
+### [`ERC1820Registry`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/ERC1820Registry.sol)
+[ERC1820](https://eips.ethereum.org/EIPS/eip-1820) specifies a registry
+service that lets addresses report what interfaces they support and ask 
+about other addresses. 
+-->
+
+### [`Lib_AddressManager`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/libraries/resolver/Lib_AddressManager.sol)
+This is a library that stores the mappings between names and their addresses.
+It is used by [`L1CrossDomainMessenger`](#l1crossdomainmessenger).
+
+<!--
+### [`OVM_ExecutionManagerWrapper`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_ExecutionManagerWrapper.sol)
+This is the one contract on L2 that can call another contract without having to
+go through virtualization. It is used to call 
+[OVM_ExecutionManager](#ovm-executionmanager).
+
+
+### [`ERC1820Registry`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/ERC1820Registry.sol)
+[ERC1820](https://eips.ethereum.org/EIPS/eip-1820) specifies a registry
+service that lets addresses report what interfaces they support and ask 
+about other addresses. 
+
+
+-->

--- a/src/docs/protocol/protocol-2.0.md
+++ b/src/docs/protocol/protocol-2.0.md
@@ -168,14 +168,16 @@ The following concrete contracts are predeployed:
 ### [`OVM_DeployerWhitelist`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L2/predeploys/OVM_DeployerWhitelist.sol)
 The Deployer Whitelist is a temporary predeploy used to provide additional safety during the initial phases of our mainnet roll out. It is owned by the Optimism team, and defines accounts which are allowed to deploy contracts on Layer 2. The Execution Manager will only allow a `CREATE` or `CREATE2` operation to proceed if the deployer's address whitelisted.
 
-<!--
-### [`OVM_L1MessageSender`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_L1MessageSender.sol)
+
+### [`OVM_L1MessageSender`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L2/predeploys/iOVM_L1MessageSender.sol)
+
 The L1MessageSender is a predeployed contract running on L2.
 During the execution of cross domain transaction from L1 to L2, it returns the address of the L1 account (either an EOA or contract) which sent the message to L2 via the Canonical Transaction Chain's `enqueue()` function.
-This contract exclusively serves as a getter for the `ovmL1TXORIGIN` operation.
-This is necessary because there is no corresponding EVM opcode which the optimistic solidity compiler could replace with a call to the ExecutionManager's `ovmL1TXORIGIN()` function.
-That is, if a contract on L2 wants to know which L1 address initiated a call on L2, the way to do it is by calling `OVM_L1MessageSender.ovmL1TXORIGIN()`.
--->
+
+Note that this contract is not written in Solidity. However, 
+the interface linked above still works as if it were. In this way
+it is similar to the EVM's predeploys.
+
 
 ### [`OVM_L2ToL1MessagePasser`](https://github.com/ethereum-optimism/optimism/blob/experimental/packages/contracts/contracts/L2/predeploys/OVM_L2ToL1MessagePasser.sol)
 The L2 to L1 Message Passer is a utility contract which facilitate an L1 proof of the  of a message on L2. The L1 Cross Domain Messenger performs this proof in its _verifyStorageProof function, which verifies the existence of the transaction hash in this  contract's `sentMessages` mapping.

--- a/src/docs/protocol/protocol-readings.md
+++ b/src/docs/protocol/protocol-readings.md
@@ -14,6 +14,12 @@ Think we don't have enough information about a certain topic?
 Hop on the [discord](https://discord.optimism.io) and make a post in `#resources` or [open an issue](https://github.com/ethereum-optimism/community-hub/issues) in the GitHub repo for this site. ✨
 :::
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
 ## [*OVM Deep Dive*](https://medium.com/ethereum-optimism/ovm-deep-dive-a300d1085f52)
 
 * Date: May 5, 2020

--- a/src/docs/protocol/protocol.md
+++ b/src/docs/protocol/protocol.md
@@ -1,5 +1,5 @@
 ---
-title: Contract Overview
+title: Contract Overview for OVM 1.0
 lang: en-US
 tags:
     - contracts

--- a/src/docs/protocol/protocol.md
+++ b/src/docs/protocol/protocol.md
@@ -8,6 +8,12 @@ tags:
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
 <!-- This comment string does not appear in the rendered html, so it can be used for making notes.
 The following is a list of useful references that can be used in writing this doc:
 

--- a/src/docs/users/fees-2.0.md
+++ b/src/docs/users/fees-2.0.md
@@ -1,0 +1,36 @@
+---
+title: Transaction Fees in OVM 2.0
+lang: en-US
+---
+
+# {{ $frontmatter.title }}
+
+::: warning OVM 2.0 Page
+This page refers to the **new** state of Optimistic Ethereum after the
+OVM 2.0 update. We expect to deploy OVM 2.0 mid October on the Kovan
+test network and by the end of October on the production network.
+:::
+
+## Fees in a nutshell
+
+Fees on Optimistic Ethereum are, for the most part, significantly 
+lower than on the Ethereum mainnet. Every Optimistic Ethereum
+transaction has two costs:
+
+1. **L2 execution fee**. This fee is `tx.gasLimit * l2gasUsed`, 
+   where `l2gasUsed ≤ tx.gasLimit`. This is similar to the L1 cost, but
+   **much** lower (unless Optimistic Ethereum congestion is extremely high). [You 
+   can see the current cost here](https://public-grafana.optimism.io/d/9hkhMxn7z/public-dashboard?orgId=1&refresh=5m). User interfaces such
+   as wallets communicate this cost the way they communicate the
+   transaction cost in L1.
+
+   At writing the L2 gas cost in 0.001 gwei, and about 80,000 L2 gas cost the same 
+   as one L1 gas.
+
+2. **L1 security fee**. This is the cost of storing the transaction's 
+   data on L1. This cost is deducted from your Optimistic Ethereum 
+   Ether balance automatically. We are working with wallet and other
+   user interface developers to show it to the user as well.
+
+For more information about this subject, 
+[see here](/docs/developers/l2/new-fees.html).

--- a/src/docs/users/fees.md
+++ b/src/docs/users/fees.md
@@ -1,5 +1,5 @@
 ---
-title: Transaction Fees
+title: Transaction Fees in OVM 1.0
 lang: en-US
 ---
 

--- a/src/docs/users/fees.md
+++ b/src/docs/users/fees.md
@@ -5,6 +5,12 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
+::: danger OVM 1.0 Page
+This page refers to the **current** state of the Optimistic Ethereum
+network. Some of the information may be relevant to OVM 2.0, which will
+be deployed in October, but some of it may change.
+:::
+
 ## Fees in a nutshell
 
 Fees on Optimistic Ethereum are, for the most part, significantly lower than on the Ethereum mainnet.

--- a/src/faqs/README.md
+++ b/src/faqs/README.md
@@ -113,7 +113,7 @@ A Sequencer node is a special node in an Optimistic Ethereum network that can or
 
 ### Mainnet contract deployments are restricted by a whitelist
 
-Contract deployments to the Optimistic Ethereum mainnet are currently restricted by a whitelist. We are slowly introducing new applications to the mainnet system in order to reduce the available exploit surface and to throttle usage. Please fill out our [integration support signup form](https://docs.google.com/forms/u/1/d/e/1FAIpQLSdKyXpXY1C4caWD3baQBK1dPjEboOJ9dpj9flc-ursqq8KU0w/viewform) if you'd like to deploy an application to the OE mainnet. The [Optimistic Kovan testnet](https://community.optimism.io/docs/developers/networks.html#optimistic-kovan) is fully accessible to the general public.
+Contract deployments to the Optimistic Ethereum mainnet are currently restricted by a whitelist. We are slowly introducing new applications to the mainnet system in order to reduce the available exploit surface and to throttle usage. Please fill out our [integration support signup form](https://docs.google.com/forms/d/e/1FAIpQLSfBGsJN3nZQRLdMjqCS_svfQoPkn35o_cc4HUVnLlXN2BHmPw/viewform) if you'd like to deploy an application to the OE mainnet. The [Optimistic Kovan testnet](https://community.optimism.io/docs/developers/networks.html#optimistic-kovan) is fully accessible to the general public.
 
 ### Optimism's codebase is only partially audited
 


### PR DESCRIPTION
* Put a special notice on pages that are OVM 1.0 or OVM 2.0 specific
* Update that `ORIGIN` is now supported
* Update the mainnet white listing page
* Update the new fees with the completed code snippet
* Update for OVM 2.0:
    * contracts.md
    * users/fees.md
    * protocol.md
    * rpc.md




Closing: INT-179, INT-178, INT-177, INT-176, INT-126, INT-133, INT-138, INT-134