### PR TITLE
Turn Gemini and Binance name's into buttons at 'Getting Started with Optimistic Ethereum' in the User Docs.

### DIFF
--- a/src/docs/users/getting-started.md
+++ b/src/docs/users/getting-started.md
@@ -25,8 +25,8 @@ them from Mainnet Ethereum using [a bridge](/docs/users/apps.html#gateways-and-b
 mechanism is [our own gateway](https://gateway.optimism.io/).
 
 1. If you do not have any ETH, purchase some through a centralized exchange, such as 
-   [Coinbase](https://www.coinbase.com/signup), Gemini(https://exchange.gemini.com/register), 
-   or Binance(https://accounts.binance.com/en/register).
+   [Coinbase](https://www.coinbase.com/signup), [Gemini](https://exchange.gemini.com/register), 
+   or [Binance](https://accounts.binance.com/en/register).
 1. Set up a wallet, for example [Metamask](https://metamask.io/), and withdraw the ETH from the centralized
    exchange to your wallet.   
 1. [Browse to the gateway](https://gateway.optimism.io/).


### PR DESCRIPTION
**Description**
In the current version, the links for Gemini and Binance exchanges (in the depositing-assets section) appear in brackets next to their names; Unlike Coinbase, which name is used as a button.
I propose a little change that turns all exchanges names into links that lead to its corresponding exchange.

**Metadata**
- Fixes [getting-started/depositing-assets in the User Docs](https://community.optimism.io/docs/users/getting-started.html#depositing-assets)
- ![image](https://user-images.githubusercontent.com/67139425/135342486-ddf11b6c-8531-42c5-9b36-8fb66e7975b3.png)

