### PR TITLE
feat: remove 2.0 announcements and titles

### DIFF
--- a/src/docs/developers/bridge/messaging.md
+++ b/src/docs/developers/bridge/messaging.md
@@ -3,19 +3,7 @@ title: Sending Data Between L1 and L2
 lang: en-US
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 # {{ $frontmatter.title }}
-
-::: danger OVM 1.0 Page
-This page refers to the **current** state of the Optimistic Ethereum
-network. Some of the information may be relevant to OVM 2.0, which will
-be deployed in November, but some of it may change.
-:::
-
 
 Apps on Optimistic Ethereum can be made to interact with apps on Ethereum via a process called "bridging".
 In a nutshell, **contracts on Optimistic Ethereum can send messages to contracts on Ethereum, and vice versa**.

--- a/src/docs/developers/bridge/standard-bridge.md
+++ b/src/docs/developers/bridge/standard-bridge.md
@@ -3,11 +3,6 @@ title: Using the Standard Bridge
 lang: en-US
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 # {{ $frontmatter.title }}
 
 

--- a/src/docs/developers/l2/block-time.md
+++ b/src/docs/developers/l2/block-time.md
@@ -3,18 +3,7 @@ title: Block Numbers and Timestamps
 lang: en-US
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
-
 # {{ $frontmatter.title }}
-
-::: warning OVM 2.0 Page
-This page refers to the **new** state of Optimistic Ethereum after the
-OVM 2.0 update. 
-:::
 
 Block numbers and timestamps in Optimistic Ethereum are similar, but not entirely identical, to those in Ethereum.
 

--- a/src/docs/developers/l2/changeset.md
+++ b/src/docs/developers/l2/changeset.md
@@ -3,11 +3,6 @@ title: OVM 2.0 Changeset
 lang: en-US
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 # {{ $frontmatter.title }}
 
 For OVM 2.0 we will have a series of breaking changes as a part of an upgrade to the OVM. Fundamentally, this will drastically reduce the differences between the OVM and EVM so that developers can implement their contracts with mostly just one target in mind, instead of managing OVM idiosyncrasies with separate contracts. Thus the changes can be viewed as a reversion to most things listed on this page [https://community.optimism.io/docs/protocol/evm-comparison.html](../../protocol/evm-comparison.md). Here is the list of key breaking changes to watch for:

--- a/src/docs/developers/l2/contracts-2.0.md
+++ b/src/docs/developers/l2/contracts-2.0.md
@@ -1,20 +1,9 @@
 ---
-title: Using the Protocol Contracts in OVM 2.0
+title: Using the Protocol Contracts
 lang: en-US
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
-
 # {{ $frontmatter.title }}
-
-::: warning OVM 2.0 Page
-This page refers to the **new** state of Optimistic Ethereum after the
-OVM 2.0 update. 
-:::
 
 ## Finding contract addresses
 

--- a/src/docs/developers/l2/convert-2.0.md
+++ b/src/docs/developers/l2/convert-2.0.md
@@ -1,14 +1,9 @@
 ---
-title: Porting Existing Apps to OVM 2.0
+title: Porting Existing Apps
 lang: en-US
 ---
 
 # {{ $frontmatter.title }}
-
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
 
 ## Differences from L1 Ethereum
 

--- a/src/docs/developers/l2/deploy.md
+++ b/src/docs/developers/l2/deploy.md
@@ -3,11 +3,6 @@ title: Deploying to Mainnet
 lang: en-US
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 # {{ $frontmatter.title }}
 
 ::: warning NOTICE

--- a/src/docs/developers/l2/dev-node.md
+++ b/src/docs/developers/l2/dev-node.md
@@ -3,11 +3,6 @@ title: Running a Development Node
 lang: en-US
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 # {{ $frontmatter.title }}
 
 ::: tip

--- a/src/docs/developers/l2/future.md
+++ b/src/docs/developers/l2/future.md
@@ -3,11 +3,6 @@ title: Future Proofing your Optimistic Dapp
 lang: en-US
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 # {{ $frontmatter.title }}
 
 ::: warning NOTICE

--- a/src/docs/developers/l2/new-fees.md
+++ b/src/docs/developers/l2/new-fees.md
@@ -1,19 +1,9 @@
 ---
-title: Fee Scheme in OVM 2.0
+title: Transaction Fees for Developers
 lang: en-US
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 # {{ $frontmatter.title }}
-
-::: warning OVM 2.0 Page
-This page refers to the **new** state of Optimistic Ethereum after the
-OVM 2.0 update. 
-:::
 
 You can see how the fee is calculated and deducted [here](../../users/fees-2.0.md).
 

--- a/src/docs/developers/l2/rpc-2.0.md
+++ b/src/docs/developers/l2/rpc-2.0.md
@@ -1,19 +1,9 @@
 ---
-title: JSON-RPC API Differences in OVM 2.0
+title: JSON-RPC API Differences
 lang: en-US
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 # {{ $frontmatter.title }}
-
-::: warning OVM 2.0 Page
-This page refers to the **new** state of Optimistic Ethereum after the
-OVM 2.0 update. 
-:::
 
 Most JSON-RPC methods in Optimistic Ethereum are identical to the corresponding methods in the Ethereum JSON-RPC API.
 However, a few JSON-RPC methods have been added or changed to better fit the needs of Optimistic Ethereum.

--- a/src/docs/developers/l2/tooling-2.0.md
+++ b/src/docs/developers/l2/tooling-2.0.md
@@ -1,15 +1,9 @@
 ---
-title: Tooling in OVM 2.0
+title: Tooling
 lang: en-US
 ---
 
 # {{ $frontmatter.title }}
-
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 
 There is no more need for special tooling. Just add 
 [the appropriate Optimistic Network](../../infra/networks.md) to the

--- a/src/docs/developers/talks.md
+++ b/src/docs/developers/talks.md
@@ -6,13 +6,6 @@ tags:
     - high-level
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
-
-
 # {{ $frontmatter.title }}
 
 ## [*Tips and Tricks to Deploy L1 Smart Contracts on Optimism*](https://www.youtube.com/watch?v=cAxQJS7YZPY)

--- a/src/docs/developers/tutorials.md
+++ b/src/docs/developers/tutorials.md
@@ -5,11 +5,6 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 ## Getting Started
 
 * [Optimistic Ethereum with Hardhat](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/hardhat)

--- a/src/docs/developers/util.md
+++ b/src/docs/developers/util.md
@@ -3,22 +3,9 @@ title: Useful Contracts
 lang: en-US
 ---
 
-
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
-
 # {{ $frontmatter.title }}
 
-::: tip OVM 2.0 Page
-This page refers to the OVM 2.0 Kovan test network. It will be updated for
-the production network after it is released.
-:::
-
 These are contracts that are expected to be useful for multiple projects.
-
 
 ## Optimism
 

--- a/src/docs/infra/monitoring.md
+++ b/src/docs/infra/monitoring.md
@@ -3,12 +3,6 @@ title: Monitoring
 lang: en-US
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
-
 # {{ $frontmatter.title }}
 
 * [Optimism public dashboard](https://public-grafana.optimism.io/d/9hkhMxn7z/public-dashboard?orgId=1&refresh=5m)

--- a/src/docs/infra/networks.md
+++ b/src/docs/infra/networks.md
@@ -3,14 +3,7 @@ title: Networks and Connection Details
 lang: en-US
 ---
 
-
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 # {{ $frontmatter.title }}
-
 
 ## Development Node
 

--- a/src/docs/protocol/evm-comparison.md
+++ b/src/docs/protocol/evm-comparison.md
@@ -6,12 +6,6 @@ tags:
     - high-level
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
-
 # {{ $frontmatter.title }}
 
 ::: danger OVM 1.0 Page

--- a/src/docs/protocol/protocol-2.0.md
+++ b/src/docs/protocol/protocol-2.0.md
@@ -1,25 +1,12 @@
 ---
-title: Contract Overview for OVM 2.0
+title: Contract Overview
 lang: en-US
 tags:
     - contracts
     - high-level
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
-
-
 # {{ $frontmatter.title }}
-
-::: warning OVM 2.0 Page
-This page refers to the **new** state of Optimistic Ethereum after the
-OVM 2.0 update.
-:::
-
 
 ## Introduction
 

--- a/src/docs/protocol/protocol-readings.md
+++ b/src/docs/protocol/protocol-readings.md
@@ -6,12 +6,6 @@ tags:
     - high-level
 ---
 
-
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 # {{ $frontmatter.title }}
 
 ::: tip Are we missing something? 🧐

--- a/src/docs/protocol/sequencing.md
+++ b/src/docs/protocol/sequencing.md
@@ -5,12 +5,6 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
-
 ## What is a sequencer?
 
 Optimistic Ethereum block production is primarily managed by a single party, called the "sequencer," which helps the network by providing the following services:

--- a/src/docs/pub-goods/talks.md
+++ b/src/docs/pub-goods/talks.md
@@ -6,13 +6,6 @@ tags:
     - high-level
 ---
 
-
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
-
 # {{ $frontmatter.title }}
 
 ## [*ETHOnline 2021 | Kick off Talk Retroactive Public Goods Funding*](https://www.youtube.com/watch?v=OrrkuUlFfOQ)

--- a/src/docs/users/deposit.md
+++ b/src/docs/users/deposit.md
@@ -5,11 +5,6 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 ## Which Assets?
 
 ### Ether

--- a/src/docs/users/fees-2.0.md
+++ b/src/docs/users/fees-2.0.md
@@ -1,20 +1,9 @@
 ---
-title: Transaction Fees in OVM 2.0
+title: Transaction Fees
 lang: en-US
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
-
 # {{ $frontmatter.title }}
-
-::: warning OVM 2.0 Page
-This page refers to the **new** state of Optimistic Ethereum after the
-OVM 2.0 update.
-:::
 
 ## Fees in a nutshell
 

--- a/src/docs/users/getting-started.md
+++ b/src/docs/users/getting-started.md
@@ -5,11 +5,6 @@ lang: en-US
 
 # {{ $frontmatter.title }}
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 ## Why use Optimistic Ethereum?
 
 The Optimistic Ethereum network lets you send transactions, similar to Ethereum, but

--- a/src/docs/users/metamask.md
+++ b/src/docs/users/metamask.md
@@ -3,11 +3,6 @@ title: Connecting via MetaMask
 lang: en-US
 ---
 
-::: tip OVM 2.0 Release Dates
-OVM 2.0 is already released on the Kovan test network.
-We expect to deploy it to the production Optimistic Ethereum network on November 11th.
-:::
-
 # {{ $frontmatter.title }}
 
 ## Connecting with chainid.link


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Removes the OVM 2.0 announcements and removes "in 2.0" from titles that had it.
