### PR TITLE
Remove OVM v1 reference and update branch name of OVM v2

### DIFF
--- a/src/docs/developers/l2/dev-node.md
+++ b/src/docs/developers/l2/dev-node.md
@@ -57,16 +57,10 @@ If you want to download the images, perform these steps:
 1. Clone the [Optimism monorepo](https://github.com/ethereum-optimism/optimism).
    The branch to clone depends on the OVM version you need.
 
-   - For OVM 1.0, use the `main` branch.
+   - For OVM 2.0, use the `develop` branch.
 
      ```sh
-     git clone https://github.com/ethereum-optimism/optimism.git
-     ```
-
-   - For OVM 2.0, use the `regenesis/0.5` branch.
-
-     ```sh
-     git clone https://github.com/ethereum-optimism/optimism.git -b regenesis/0.5
+     git clone https://github.com/ethereum-optimism/optimism.git -b develop
      ```
 
 2. Download the images from [the Docker 

--- a/src/docs/developers/l2/dev-node.md
+++ b/src/docs/developers/l2/dev-node.md
@@ -54,10 +54,7 @@ Hub](https://hub.docker.com/u/ethereumoptimism) or build the software from the [
 If you want to download the images, perform these steps:
 
 
-1. Clone the [Optimism monorepo](https://github.com/ethereum-optimism/optimism).
-   The branch to clone depends on the OVM version you need.
-
-   - For OVM 2.0, use the `develop` branch.
+1. Clone the [Optimism monorepo](https://github.com/ethereum-optimism/optimism) and use the `develop` branch.
 
      ```sh
      git clone https://github.com/ethereum-optimism/optimism.git -b develop


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Remove OVM 1.0 docker image and update the correct branch of OVM 2.0

**Metadata**
- Fixes #295 
- Fixes #296  
