### PR TITLE
Add getting involved section content

### DIFF
--- a/src/.vuepress/theme/components/PageMeta.vue
+++ b/src/.vuepress/theme/components/PageMeta.vue
@@ -17,7 +17,7 @@
             </a>
           </li>
           <li>
-            <a href="https://github.com/ethereum-optimism/optimism" target="_blank" rel="noopener noreferrer">
+            <a href="https://github.com/ethereum-optimism/optimism/contribute" target="_blank" rel="noopener noreferrer">
               <i class="far fa-hands-helping"></i> Contribute to Optimism
             </a>
           </li>
@@ -97,7 +97,7 @@
     @media (max-width $MQMobile)
       font-size 13px
       text-align left
-  
+
   .footer-box
     display flex
     flex-direction row
@@ -138,7 +138,7 @@
 
         &:hover
           color #FF0420
-        
+
       i
         font-size 14px
         width 20px

--- a/src/docs/contribute/README.md
+++ b/src/docs/contribute/README.md
@@ -9,11 +9,19 @@ lang: en-US
 
 There are plenty of ways to contribute, in particular we appreciate support in the following areas:
 
+## Code contributions
+
+The Optimism codebase is maintained in a monorepo at [https://github.com/ethereum-optimism/optimism](https://github.com/ethereum-optimism/optimism). It's a [collection of packages](https://github.com/ethereum-optimism/optimism#directory-structure) all requiring different skills to maintain and evolve ranging from NodeJS and TypeScript, Solidity and EVM, Go and Geth to Docker and Kubernetes. The following are good entry points into using your coding skills to help us build Optimism:
+
 - Reporting issues. For security issues see [Security policy](https://github.com/ethereum-optimism/.github/blob/master/SECURITY.md).
+- Participate in the [Bug Bouty programme](https://immunefi.com/bounty/optimism/).
 - Fixing and responding to existing issues. You can start off with those tagged ["good first issue"](https://github.com/ethereum-optimism/optimism/contribute) which are meant as introductory issues for external contributors.
+- Work on open [bounties on Gitcoin](https://gitcoin.co/ethereum-optimism).
+
+::: tip
+Following the guidelines on [Contributing](https://github.com/ethereum-optimism/optimism/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/ethereum-optimism/.github/blob/master/CODE_OF_CONDUCT.md) in all your interactions with the project will ensure your contributions are processed by the team.
+:::
+
+## Community contributions
 - Improving this [community site](https://community.optimism.io/) [documentation](https://github.com/ethereum-optimism/community-hub) and [tutorials](https://github.com/ethereum-optimism/optimism-tutorial).
 - Become an "Optimizer" and answer questions in the [Optimism Discord](https://discord.com/invite/jrnFEvq).
-- Get involved in the protocol design process by proposing changes or new features or write parts of the spec yourself in the [optimistic-specs repo](https://github.com/ethereum-optimism/optimistic-specs).
-- We occasionally fund [bounties on Gitcoin](https://gitcoin.co/ethereum-optimism) too!
-
-You can read through the full [Contributing guidelines](https://github.com/ethereum-optimism/optimism/blob/master/CONTRIBUTING.md) and a [Code of Conduct](https://github.com/ethereum-optimism/.github/blob/master/CODE_OF_CONDUCT.md), please follow these in all your interactions with the project.

--- a/src/docs/contribute/README.md
+++ b/src/docs/contribute/README.md
@@ -1,0 +1,19 @@
+---
+title: Contribute to Optimism
+lang: en-US
+---
+
+# {{ $frontmatter.title }}
+
+🎈 Thanks for your help improving the project! We are so happy to have you!
+
+There are plenty of ways to contribute, in particular we appreciate support in the following areas:
+
+- Reporting issues. For security issues see [Security policy](https://github.com/ethereum-optimism/.github/blob/master/SECURITY.md).
+- Fixing and responding to existing issues. You can start off with those tagged ["good first issue"](https://github.com/ethereum-optimism/optimism/contribute) which are meant as introductory issues for external contributors.
+- Improving this [community site](https://community.optimism.io/) [documentation](https://github.com/ethereum-optimism/community-hub) and [tutorials](https://github.com/ethereum-optimism/optimism-tutorial).
+- Become an "Optimizer" and answer questions in the [Optimism Discord](https://discord.com/invite/jrnFEvq).
+- Get involved in the protocol design process by proposing changes or new features or write parts of the spec yourself in the [optimistic-specs repo](https://github.com/ethereum-optimism/optimistic-specs).
+- We occasionally fund [bounties on Gitcoin](https://gitcoin.co/ethereum-optimism) too!
+
+You can read through the full [Contributing guidelines](https://github.com/ethereum-optimism/optimism/blob/master/CONTRIBUTING.md) and a [Code of Conduct](https://github.com/ethereum-optimism/.github/blob/master/CODE_OF_CONDUCT.md), please follow these in all your interactions with the project.


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Add a dedicated page for providing a direction to external contributors. This is intentionally mostly the same as the first section of the [Contributing guidelines](https://github.com/ethereum-optimism/optimism/blob/3174f034da022ac7ebcfde4ebd08961e377b43c3/CONTRIBUTING.md) to keep guidelines consistent.

Also updates footer 'Contribute to Optimism' link to navigate to the monorepo contribute section

**Metadata**
- Fixes INT-382
