### PR TITLE
Decommission the standard token tutorial in favour of the guide

### DIFF
--- a/src/docs/developers/bridge/standard-bridge.md
+++ b/src/docs/developers/bridge/standard-bridge.md
@@ -45,7 +45,7 @@ Instead, you can use the `withdraw` or `withdrawTo` functions on the [`L2Standar
 ## Adding an ERC20 token to the Standard Bridge
 
 ::: tip
-To add your token to the standard bridge, see the guide [Adding an ERC20 token to the Standard Bridge](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/standard-bridge-standard-token).
+To add your token to the standard bridge, see the guide [Adding an ERC20 token to the Standard Bridge](../../guides/token-dev.md).
 :::
 
 ## The Optimism token list

--- a/src/docs/developers/tutorials.md
+++ b/src/docs/developers/tutorials.md
@@ -12,5 +12,4 @@ lang: en-US
 ## ERC-20 Tokens
 
 * [Depositing and Withdrawing ERC20 Tokens](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/l1-l2-deposit-withdrawal)
-* [Registering a Standard ERC20 Token on L2](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/standard-bridge-standard-token)
 * [Registering a Custom ERC20 Token on L2](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/standard-bridge-custom-token)

--- a/src/docs/protocol/protocol-2.0.md
+++ b/src/docs/protocol/protocol-2.0.md
@@ -123,9 +123,9 @@ The L2 Cross Domain Messenger (L2xDM) contract sends messages from L2 to L1, and
 ## The Standard Bridge
 
 One common case of message passing is "transferring" either ERC-20
-tokens or ETH between L1 and Optimism. To deposit tokens 
+tokens or ETH between L1 and Optimism. To deposit tokens
 into Optimism, the bridge locks them on L1 and mints equivalent
-tokens in Optimism. To withdraw tokens, the bridge burns the 
+tokens in Optimism. To withdraw tokens, the bridge burns the
 Optimism tokens and releases the locked L1 tokens. [More details
 are here](/docs/developers/bridge/standard-bridge.html)
 
@@ -139,8 +139,8 @@ The L2 part of the Standard Bridge. Responsible for finalising deposits from L1 
 
 ### [`L2StandardTokenFactory`](https://github.com/ethereum-optimism/optimism/blob/master/packages/contracts/contracts/L2/messaging/L2StandardTokenFactory.sol)
 
-Factory contract for creating standard L2 token representations of L1 ERC20s compatible with and working on the standard bridge. 
-[See here for more information](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/standard-bridge-standard-token).
+Factory contract for creating standard L2 token representations of L1 ERC20s compatible with and working on the standard bridge.
+[See here for more information](../guides/token-dev.md).
 
 
 ## Predeployed Contracts
@@ -156,7 +156,7 @@ The following concrete contracts are predeployed:
 The L1MessageSender is a predeployed contract running on L2.
 During the execution of cross domain transaction from L1 to L2, it returns the address of the L1 account (either an EOA or contract) which sent the message to L2 via the Canonical Transaction Chain's `enqueue()` function.
 
-Note that this contract is not written in Solidity. However, 
+Note that this contract is not written in Solidity. However,
 the interface linked above still works as if it were. In this way
 it is similar to the EVM's predeploys.
 
@@ -167,10 +167,10 @@ The L2 to L1 Message Passer is a utility contract which facilitate an L1 proof o
 <!--
 ### [`OVM_SequencerEntrypoint`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol)
 The Sequencer Entrypoint is a predeploy which, despite its name, can in fact be called by  any account. It accepts a more efficient compressed calldata format, which it decompresses and  encodes to the standard EIP155 transaction format. This contract is the implementation referenced by the Proxy Sequencer Entrypoint, thus enabling the Optimism team to upgrade the decompression of calldata from the Sequencer.
---> 
+-->
 
 ### [`OVM_SequencerFeeVault`](https://github.com/ethereum-optimism/optimism/blob/master/packages/contracts/contracts/L2/predeploys/OVM_SequencerFeeVault.sol)
-This contract holds fees paid to the sequencer until there is enough to 
+This contract holds fees paid to the sequencer until there is enough to
 justify the transaction cost of sending them to L1 where they are used to
 pay for L1 transaction costs (mostly the cost of publishing all L2 transaction
 data as CALLDATA on L1).
@@ -185,15 +185,15 @@ See [Standard Bridge](../developers/bridge/standard-bridge.md) for details.
 <!--
 ### [`OVM_ExecutionManagerWrapper`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_ExecutionManagerWrapper.sol)
 This is the one contract on L2 that can call another contract without having to
-go through virtualization. It is used to call 
+go through virtualization. It is used to call
 OVM_ExecutionManager  ovm-executionmanager.
 -->
 
 <!--
 ### [`ERC1820Registry`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/ERC1820Registry.sol)
 [ERC1820](https://eips.ethereum.org/EIPS/eip-1820) specifies a registry
-service that lets addresses report what interfaces they support and ask 
-about other addresses. 
+service that lets addresses report what interfaces they support and ask
+about other addresses.
 -->
 
 ### [`Lib_AddressManager`](https://github.com/ethereum-optimism/optimism/blob/master/packages/contracts/contracts/libraries/resolver/Lib_AddressManager.sol)
@@ -206,14 +206,14 @@ It is used by `L1CrossDomainMessenger`.
 <!--
 ### [`OVM_ExecutionManagerWrapper`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_ExecutionManagerWrapper.sol)
 This is the one contract on L2 that can call another contract without having to
-go through virtualization. It is used to call 
+go through virtualization. It is used to call
  OVM_ExecutionManager  ovm-executionmanager .
 
 
 ### [`ERC1820Registry`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/ERC1820Registry.sol)
 [ERC1820](https://eips.ethereum.org/EIPS/eip-1820) specifies a registry
-service that lets addresses report what interfaces they support and ask 
-about other addresses. 
+service that lets addresses report what interfaces they support and ask
+about other addresses.
 
 
 -->


### PR DESCRIPTION
**Description**
Decommission the [Standard bridge - standard token tutorial](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/standard-bridge-standard-token) in favour of the much simpler guide [here](https://community.optimism.io/docs/guides/token-dev/)  

