### PR TITLE
feat: add new testnet faucet

### DIFF
--- a/src/docs/useful-tools/faucets.md
+++ b/src/docs/useful-tools/faucets.md
@@ -15,6 +15,10 @@ Just sign in with Twitter and you'll automatically be sent 1 ETH, 1 wETH, 500 DA
 [Optifaucet](https://kovan.optifaucet.com/) gives you a small amount of ETH, and 10,000 USDC. 
 They do this because you need USDC to [use their application](https://testnet.perp.exchange/).
 
+### Optimism Kovan Faucet
+
+[Optimism Faucet](https://optimismfaucet.xyz/) is a simple faucet for Optimism Kovan that drips ETH and DAI. Authenticate with github, enter your wallet address and you'll aumatically be sent 1 ETH and 100 DAI on the Optimism Kovan testnet.
+
 
 ## Mainnet Faucets
 


### PR DESCRIPTION
Even though Paradigm's Multifaucet is amazing I believe some devs can't use it if they don't have `twitter` so I created this simple faucet that uses `github` for authenicating. You can check the project here https://github.com/tonykogias/optimism-faucet

I think it's worth adding it to the faucet list on the community website.
