### PR TITLE
issue template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bridge-bug.yml
+++ b/.github/ISSUE_TEMPLATE/bridge-bug.yml
@@ -1,0 +1,45 @@
+name: Bridge Bug Report
+description: File a bug report on the Optimism Bridge
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a bug report, please search for the behaviour in the existing issues. 
+        
+        ---
+        
+        Thank you for taking the time to file a bug report. To address this bug as fast as possible, we need some information.
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: "Which operating system do you use? Please provide the version as well."
+      placeholder: "macOS Big Sur 11.5.2"
+    validations:
+      required: true  
+  - type: input
+    id: Browser
+    attributes:
+      label: Browser 
+      description: "What browser are you using, and what version is it running?"
+      placeholder: "Chrome v100.0"
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug description
+      description: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Which steps do we need to take to reproduce this error?
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: If applicable, provide relevant log output. No need for backticks here.
+      render: shell


### PR DESCRIPTION
Adds an issue template for users to report bugs they encounter on the OP gateway. 

This will be used temporarily until we have a more robust reporting system set up. 