### PR TITLE
Fix L1 to L2 Deposit Example Link

### DIFF
--- a/src/docs/developers/bridge/standard-bridge.md
+++ b/src/docs/developers/bridge/standard-bridge.md
@@ -39,7 +39,7 @@ Once your deposit is detected and finalized on Optimism, your account will be fu
 ### Withdrawing ERC20s
 
 ERC20 withdrawals can be triggered via the `withdraw` or `withdrawTo` functions on the [`L2StandardBridge`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/L2/messaging/L2StandardBridge.sol).
-If you'd like to see this contracts in action, you should check out the [L1 ⇔ L2 deposit-and-withdraw example](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/l1-l2-deposit-withdrawal).
+If you'd like to see this contracts in action, you should check out the [L1 ⇔ L2 deposit-and-withdraw example](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/cross-dom-bridge).
 
 ### Withdrawing ETH
 


### PR DESCRIPTION
**Description**
Broken Link:
Under `Bridging L1 and L2` > `Using Standard Token Bridge` > [Withdrawing ERC20s](https://community.optimism.io/docs/developers/bridge/standard-bridge/#withdrawing-erc20s) 
the link `[L1 ⇔ L2 deposit-and-withdraw example (opens new window)]` gives "404: The 'ethereum-optimism/optimism-tutorial' repository doesn't contain the 'l1-l2-deposit-withdrawal' path in 'main'."

Fix: 
Links to: https://github.com/ethereum-optimism/optimism-tutorial/tree/main/l1-l2-deposit-withdrawal
Corrected link: https://github.com/ethereum-optimism/optimism-tutorial/tree/main/cross-dom-bridge


**Metadata**
- Fixes #423