### PR TITLE
Update dynamic overhead in tx fees

### DIFF
--- a/src/docs/developers/build/transaction-fees.md
+++ b/src/docs/developers/build/transaction-fees.md
@@ -40,7 +40,7 @@ This fee is based on four factors:
 1. The current gas price on Ethereum.
 2. The gas cost to publish the transaction to Ethereum. This scales roughly with the size of the transaction (in bytes).
 3. A fixed overhead cost denominated in gas. This is currently set to 2100.
-4. A dynamic overhead cost which scales the L1 fee paid by a fixed number. This is currently set to 1.24.
+4. A dynamic overhead cost which scales the L1 fee paid by a fixed number. This is currently set to 1.0.
 
 Here's the math:
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updating docs to show 1.0 dynamic fee scalar per a previous parameter update.
<!--
**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
-->