### PR TITLE
feat(faucets): Update https://optimismfaucet.xyz to Goerli

### DIFF
--- a/src/docs/developers/bedrock.md
+++ b/src/docs/developers/bedrock.md
@@ -294,7 +294,7 @@ There are some differences between Ethereum and Optimism in this regard:
 - The EIP 1559 parameters have different values.
   Once those values are finalized they will be posted here.
 
-<!-- GOON: Put values here when they are finalized
+<!-- TODO: Put values here when they are finalized
 -->
 
 The L1 security fee, which is normally the majority of the transaction cost, uses the same mechanism as before the upgrade.

--- a/src/docs/useful-tools/faucets.md
+++ b/src/docs/useful-tools/faucets.md
@@ -5,18 +5,26 @@ lang: en-US
 
 ## Testnet Faucets
 
-Each of these faucets can be used to get testnet funds on Optimism Kovan. 
-If one of them does not work, please try another one. 
-If you need more help, head over to **#dev-support** [on our Discord](https://discord--gateway.optimism.io).
+### Optimism Goerli Faucet
 
-Once you have the test ETH on Goerli, send it to [0x636Af16bf2f682dD3109e60102b8E1A089FedAa8](https://goerli.etherscan.io/address/0x636Af16bf2f682dD3109e60102b8E1A089FedAa8), you will get it on Optimism Goerli.
+[Optimism Faucet](https://optimismfaucet.xyz/) is a simple faucet for Optimism Goerli that drips ETH and OP. 
+Authenticate with github, enter your wallet address and you'll automatically be sent 1 ETH and 100 OP on the Optimism Goerli testnet.
 
-### Paradigm MultiFaucet
+You need to be following at least five people or organizations on github to be considered a real account. If you don't, follow more, log out of the faucet, and log back in.
+
+Note that you're also able to use it for Optimism Kovan for now.
+
+### Goerli Faucets
+
+These are faucets you can use to get test ETH on Goerli. 
+Once you have that Goerli, send it to [0x636Af16bf2f682dD3109e60102b8E1A089FedAa8](https://goerli.etherscan.io/address/0x636Af16bf2f682dD3109e60102b8E1A089FedAa8), you will get it on Optimism Goerli.
+
+#### Paradigm MultiFaucet
 
 [Paradigm's MultiFaucet](https://faucet.paradigm.xyz/) is an easy way to get ETH on many different testnets at the same time.
 One of those networks is Goerli.
 
-### Goerli Faucet
+#### Goerli Faucet
 
 You can also get Goerli ETH [here](https://goerlifaucet.com/).
 
@@ -29,10 +37,6 @@ These faucets are for the deprecated Kovan test network.
 
 [Optifaucet](https://kovan.optifaucet.com/) gives you a small amount of ETH, and 10,000 USDC. 
 They do this because you need USDC to [use their application](https://testnet.perp.exchange/).
-
-#### Optimism Kovan Faucet
-
-[Optimism Faucet](https://optimismfaucet.xyz/) is a simple faucet for Optimism Kovan that drips ETH and DAI. Authenticate with github, enter your wallet address and you'll aumatically be sent 1 ETH and 100 DAI on the Optimism Kovan testnet.
 
 
 ## Mainnet Faucets

--- a/src/docs/useful-tools/faucets.md
+++ b/src/docs/useful-tools/faucets.md
@@ -8,7 +8,7 @@ lang: en-US
 ### Optimism Goerli Faucet
 
 [Optimism Faucet](https://optimismfaucet.xyz/) is a simple faucet for Optimism Goerli that drips ETH and OP. 
-Authenticate with github, enter your wallet address and you'll automatically be sent 1 ETH and 100 OP on the Optimism Goerli testnet.
+Authenticate with github, enter your wallet address and you'll automatically be sent 0.1 ETH and 100 OP (if available) on the Optimism Goerli testnet.
 
 You need to be following at least five people or organizations on github to be considered a real account. If you don't, follow more, log out of the faucet, and log back in.
 

--- a/src/docs/useful-tools/faucets.md
+++ b/src/docs/useful-tools/faucets.md
@@ -5,8 +5,6 @@ lang: en-US
 
 ## Testnet Faucets
 
-### Optimism Goerli Faucet
-
 [Optimism Faucet](https://optimismfaucet.xyz/) is a simple faucet for Optimism Goerli that drips ETH and OP. 
 Authenticate with github, enter your wallet address and you'll automatically be sent 0.2 ETH and 100 OP (if available) on the Optimism Goerli testnet.
 
@@ -17,7 +15,7 @@ Note that you're also able to use it for Optimism Kovan for now.
 ### Goerli Faucets
 
 These are faucets you can use to get test ETH on Goerli. 
-Once you have that Goerli, send it to [0x636Af16bf2f682dD3109e60102b8E1A089FedAa8](https://goerli.etherscan.io/address/0x636Af16bf2f682dD3109e60102b8E1A089FedAa8), you will get it on Optimism Goerli.
+Once you have that Goerli, use [the Optimism Bridge](https://app.optimism.io/bridge) to get it on Optimism Goerli.
 
 #### Paradigm MultiFaucet
 

--- a/src/docs/useful-tools/faucets.md
+++ b/src/docs/useful-tools/faucets.md
@@ -8,7 +8,7 @@ lang: en-US
 ### Optimism Goerli Faucet
 
 [Optimism Faucet](https://optimismfaucet.xyz/) is a simple faucet for Optimism Goerli that drips ETH and OP. 
-Authenticate with github, enter your wallet address and you'll automatically be sent 0.1 ETH and 100 OP (if available) on the Optimism Goerli testnet.
+Authenticate with github, enter your wallet address and you'll automatically be sent 0.2 ETH and 100 OP (if available) on the Optimism Goerli testnet.
 
 You need to be following at least five people or organizations on github to be considered a real account. If you don't, follow more, log out of the faucet, and log back in.
 

--- a/src/docs/useful-tools/networks.md
+++ b/src/docs/useful-tools/networks.md
@@ -78,9 +78,8 @@ We have [several providers](./providers.md) that support Optimism Goerli.
 
 ### Test ETH
 
-You can obtain Goerli test ETH either [here](https://goerlifaucet.com/) or [here](https://faucet.paradigm.xyz/).
-
-Transfer Goerli ETH to [0x636Af16bf2f682dD3109e60102b8E1A089FedAa8](https://goerli.etherscan.io/address/0x636Af16bf2f682dD3109e60102b8E1A089FedAa8), and you will get it on Optimism Goerli.
+[The Optimism Faucet](https://optimismfaucet.xyz/) now provides Optimism Goerli ETH.
+Alternatively, if you already have Goerli ETH, you can [bridge it](https://app.optimism.io/bridge).
 
 
 ## Optimism Kovan (old testnet)

--- a/src/docs/useful-tools/networks.md
+++ b/src/docs/useful-tools/networks.md
@@ -56,7 +56,6 @@ An important limitation is that public endpoint does not support the `eth_getLog
 
 ::: tip Purpose
 This is our new test network.
-It is still very much work in progress.
 :::
 
 


### PR DESCRIPTION
1. Update that https://optimismfaucet.xyz/ now works with Optimism Goerli
2. Remove the statement that Optimism Goerli is very much work in progress, because it's now supported by a lot more infrastructure.
3. Update that https://app.optimism.io/bridge now works with Optimism Goerli.


Closing: DOCS-633