### PR TITLE
Fix: typo in standard-bridge.md

### DIFF
--- a/src/docs/developers/bridge/standard-bridge.md
+++ b/src/docs/developers/bridge/standard-bridge.md
@@ -25,7 +25,7 @@ If you want to deposit using a smart contract wallet and you know what you're do
 
 ### Depositing ERC20s
 
-ERC20 deposits into L2 can triggered via the `depositERC20` and `depositERC20To` functions on the [`L1StandardBridge`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol).
+ERC20 deposits into L2 can be triggered via the `depositERC20` and `depositERC20To` functions on the [`L1StandardBridge`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol).
 You **must** approve the Standard Token Bridge to use the amount of tokens that you want to deposit or the deposit will fail.
 
 ### Depositing ETH


### PR DESCRIPTION

**Description**
Typo fix in the documentation

