### PR TITLE
feat(*): Replaced Alchemy links to affiliate ones

### DIFF
--- a/src/docs/developers/build/dev-node.md
+++ b/src/docs/developers/build/dev-node.md
@@ -9,7 +9,7 @@ A development environment is a local installation of the entire Optimism system.
 Our default development environment includes both L1 and L2 development nodes.
 Running the Optimism environment locally is a great way to test your code and see how your contracts will behave on Optimism before you graduate to a testnet deployment (and eventually a mainnet deployment).
 
-Alternatively, you can get a hosted development node from [Alchemy](https://www.alchemy.com/layer2/optimism) or [QuickNode](https://www.quicknode.com/chains/optimism). 
+Alternatively, you can get a hosted development node from [Alchemy](https://www.alchemy.com/optimism) or [any of these providers](../../useful-tools/providers.md).
 
 
 ## Do I need this?

--- a/src/docs/developers/build/run-a-node.md
+++ b/src/docs/developers/build/run-a-node.md
@@ -7,7 +7,7 @@ If you're looking to build an app on Optimism you'll need access to an Optimism 
 
 ## Hosted node providers
 
-You can get a free, hosted one from [any of these providers](../../useful-tools/providers.md) to get up and building quickly. Of them, [Alchemy](https://www.alchemy.com/layer2/optimism/?a=818c11a8da) is our preferred node provider, and is used to power our [public endpoint](https://community.optimism.io/docs/useful-tools/networks/). 
+You can get a free, hosted one from [any of these providers](../../useful-tools/providers.md) to get up and building quickly. Of them, [Alchemy](https://www.alchemy.com/optimism) is our preferred node provider, and is used to power our [public endpoint](../../useful-tools/networks.md). 
 
 However, you might be interested in running your very own Optimism node.
 Here we'll go over the process of running a testnet or mainnet Optimism node for yourself.

--- a/src/docs/guides/cex-dev.md
+++ b/src/docs/guides/cex-dev.md
@@ -9,7 +9,7 @@ You connect to Optimism the same way you do to Ethereum, by connecting to a JSON
 
 ### Endpoints
 
-[Click here for the Optimism endpoints](../useful-tools/networks.md). You can choose between our public endpoints, which are rate limited, and [endpoints from infrastructure providers](../useful-tools/networks.md). Given rate throughput limits, we recommend using a private rpc provider like [Alchemy](https://www.alchemy.com/layer2/optimism/?a=818c11a8da) for both mainnet and testnet use cases. 
+[Click here for the Optimism endpoints](../useful-tools/networks.md). You can choose between our public endpoints, which are rate limited, and [endpoints from infrastructure providers](../useful-tools/networks.md). Given rate throughput limits, we recommend using a private rpc provider like [Alchemy](https://www.alchemy.com/optimism) for both mainnet and testnet use cases. 
 
 ### ETH balance
 

--- a/src/docs/guides/wallet-dev.md
+++ b/src/docs/guides/wallet-dev.md
@@ -14,7 +14,7 @@ These fee discrepancies are an inherent result of the fact that Optimism is a La
 Optimism shares the [Ethereum JSON-RPC API](https://eth.wiki/json-rpc/API) with only [a few minor differences](../developers/build/json-rpc.md).
 You'll find all of the important information about each Optimism network on [our Networks page](../useful-tools/networks.md).
 You can choose to connect to Optimism via our rate-limited public endpoints, [private endpoints from infrastructure providers](../useful-tools/networks.md), or [by running your own node](../developers/build/run-a-node/).
-Because of throughput limits, we recommend using private node providers (particularly [Alchemy](https://www.alchemy.com/layer2/optimism/?a=818c11a8da)) or running your own node for production applications.
+Because of throughput limits, we recommend using private node providers (particularly [Alchemy](https://www.alchemy.com/optimism)) or running your own node for production applications.
 
 ## Canonical token addresses
 

--- a/src/docs/useful-tools/networks.md
+++ b/src/docs/useful-tools/networks.md
@@ -4,7 +4,7 @@ lang: en-US
 ---
 
 ::: tip Developer Tip
-We recommend using [Alchemy](https://www.alchemy.com/layer2/optimism/?a=818c11a8da) for its scalablity, reliability, and data accuracy. 
+We recommend using [Alchemy](https://www.alchemy.com/optimism) for its scalablity, reliability, and data accuracy. 
 :::
 
 ::: warning
@@ -35,14 +35,14 @@ If you need a general purpose WebSocket endpoint, get one from a service provide
 
 ### API Options:
 
-1. Get free access to Optimism through [Alchemy](https://www.alchemy.com/layer2/optimism/?a=818c11a8da)
+1. Get free access to Optimism through [Alchemy](https://www.alchemy.com/optimism)
 
 2. For small scale tests, you can use our public API:
 - HTTP endpoint: [https://mainnet.optimism.io](https://mainnet.optimism.io) (note, this is for testing. For production, use Alchemy) 
 - WebSocket endpoint (limited usage, see footnote below the table): [wss://ws-mainnet.optimism.io](wss://ws-mainnet.optimism.io)
 
 
-You can run a large application for free using [Alchemy](https://www.alchemy.com/layer2/optimism/?a=818c11a8da). We’ve done extensive diligence and Alchemy is our recommendation due to reliability, scalability, and data correctness. They're the default API provider and developer platform for top projects like OpenSea and Facebook. 
+You can run a large application for free using [Alchemy](https://www.alchemy.com/optimism). We’ve done extensive diligence and Alchemy is our recommendation due to reliability, scalability, and data correctness. They're the default API provider and developer platform for top projects like OpenSea and Facebook. 
 
 ## Optimism Goerli
 
@@ -67,13 +67,13 @@ This is our new test network.
 ### API Options
 
 
-1. Get free access to Optimism through [Alchemy](https://www.alchemy.com/layer2/optimism/?a=818c11a8da)
+1. Get free access to Optimism through [Alchemy](https://www.alchemy.com/optimism)
 
 2. For small scale tests, you can use our public API:
 - HTTP endpoint: [https://goerli.optimism.io](https://goerli.optimism.io) (note, this is for testing. For production, use Alchemy) 
 - WebSocket endpoint (limited usage, see footnote below the table): [wss://ws-goerli.optimism.io](wss://ws-goerli.optimism.io)
 
-You can run a large application for free using [Alchemy](https://www.alchemy.com/layer2/optimism/?a=818c11a8da). We’ve done extensive diligence and Alchemy is our recommendation due to reliability, scalability, and data correctness. They're the default API provider and developer platform for top projects like OpenSea and Facebook. 
+You can run a large application for free using [Alchemy](https://www.alchemy.com/optimism). We’ve done extensive diligence and Alchemy is our recommendation due to reliability, scalability, and data correctness. They're the default API provider and developer platform for top projects like OpenSea and Facebook. 
 
 
 

--- a/src/docs/useful-tools/providers.md
+++ b/src/docs/useful-tools/providers.md
@@ -11,7 +11,8 @@ Some API calls, such as the those in the [personal namespace](https://geth.ether
 Such RPCs are either totally unsupported, or will return nonsensical values.
 
 ::: tip
-**We strongly recommend all developers use [Alchemy](https://www.alchemy.com/layer2/optimism/?a=818c11a8da). We’ve done extensive diligence and Alchemy powers our public API. ** 
+**We strongly recommend all developers use [Alchemy](https://www.alchemy.com/optimism). 
+We’ve done extensive diligence and Alchemy powers our public API. ** 
 
 We recommend Alchemy due to (a) the reliability, scalability and data correctness of its developer platform and (b) the comprehensive set of tooling and APIs they provide. You can run large applications on their massive free tier. 
 
@@ -23,6 +24,7 @@ _(1) Alchemy's enhanced features_
 
 Alchemy's free private RPC endpoint provides a complimentary suite of proprietary tools. These include a custom-built [Ethers.js SDK](https://www.alchemy.com/sdk/?a=818c11a8da) (which are supersets of the Ethers.js Provider and Wallet libraries) and [enhanced APIs](https://www.alchemy.com/enhanced-apis/?a=818c11a8da) such as NFT, Transfers, and Notify APIs.
 
+https://www.alchemy.com/optimism/sdk
 
 _(2) Alchemy's hosted Optimism nodes_
 
@@ -34,7 +36,7 @@ Alchemy hosts our public API because of its data accuracy, reliability, and scal
 - Optimism Ethereum
 - Optimism Goerli
 
-[Sign up for a free Alchemy account here](https://www.alchemy.com/layer2/optimism/?a=818c11a8da).
+[Sign up for a free Alchemy account here](https://www.alchemy.com/optimism).
 
 
 ## Blast


### PR DESCRIPTION
We want people to go to https://www.alchemy.com/optimism, which then redirects them to https://www.alchemy.com/layer2/optimism? .

Note that there are other Alchemy links that are deeper, which this commit does not change
