### PR TITLE
fix(networks): Fix a developer tip to be not all headline

### DIFF
--- a/src/docs/useful-tools/networks.md
+++ b/src/docs/useful-tools/networks.md
@@ -26,7 +26,8 @@ Such RPCs are either totally unsupported, or will return nonsensical values.
 | L2 Contract Addresses | [link](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts/deployments/mainnet#layer-2-contracts) |
 | chainid.link | [https://chainid.link/?network=optimism](https://chainid.link/?network=optimism)
 
-::: tip Developer Tip If you are seeing rate limit issues when testing with the public end point, or if you need websocket functionality, we recommend signing up for [Alchemy's](https://www.alchemy.com/optimism) free trial 
+::: tip Developer Tip 
+If you are seeing rate limit issues when testing with the public end point, or if you need websocket functionality, we recommend signing up for [Alchemy's](https://www.alchemy.com/optimism) free trial.
 :::
 
 (1) Some API calls, such as those in the [personal namespace](https://geth.ethereum.org/docs/rpc/ns-personal) make no sense in a shared environment.


### PR DESCRIPTION
As requested by Shelley from Alchemy:

https://optimism-workspace.slack.com/archives/C01R0SBFYHJ/p1669158128126449