### PR TITLE
fix(bedrock): Create links for dev blog

### DIFF
--- a/src/docs/developers/bedrock-temp/upgrade-guide.md
+++ b/src/docs/developers/bedrock-temp/upgrade-guide.md
@@ -1,0 +1,5 @@
+
+<script>
+location.href = "/docs/developers/bedrock/upgrade-guide/"
+// console.log(location.href)
+</script>

--- a/src/docs/developers/bedrock.md
+++ b/src/docs/developers/bedrock.md
@@ -1,0 +1,1 @@
+bedrock/bedrock.md

--- a/src/docs/developers/bedrock.md
+++ b/src/docs/developers/bedrock.md
@@ -1,1 +1,0 @@
-bedrock/bedrock.md

--- a/src/docs/developers/bedrock/README.md
+++ b/src/docs/developers/bedrock/README.md
@@ -1,0 +1,1 @@
+bedrock.md


### PR DESCRIPTION
Temporary fix for https://dev.optimism.io/optimisms-goerli-testnet-is-migrating-to-bedrock/, because it's vacation and I'm not sure if there's anybody authorized to edit it available.