### PR TITLE
Create Link to Delegate Code of Conduct

### DIFF
--- a/src/docs/governance/delegate.md
+++ b/src/docs/governance/delegate.md
@@ -12,7 +12,7 @@ Before deciding to become a delegate you should be familiar with:
 
 * The [Working Constitution](https://gov.optimism.io/t/working-constitution-of-the-optimism-collective/55).
 * The [Operating Manual](https://github.com/ethereum-optimism/OPerating-manual/blob/main/manual.md).
-* The delegate code of conduct, once it is released.
+* The [Delegate Code of Conduct](https://gov.optimism.io/t/delegate-code-of-conduct/3943)
 
 
 ## Ready to be a delegate?


### PR DESCRIPTION
Was: The delegate code of conduct, once it is released. 

Now: The [Delegate Code of Conduct](https://gov.optimism.io/t/delegate-code-of-conduct/3943)

Added active link now that the delegate code of conduct is active 

> '...This Code of Conduct will go into effect at the start of Special Voting Cycle #9a...."

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


