### PR TITLE
Added Link to Additional Block Explorers

### DIFF
--- a/src/docs/useful-tools/monitoring.md
+++ b/src/docs/useful-tools/monitoring.md
@@ -15,6 +15,8 @@ You can view information about both the Optimism mainnet and the Optimism Goerli
 
 ## Block explorers
 
+You can find a full list of Optimism Block Explorers [here](https://www.alchemy.com/list-of/block-explorers-on-optimism). 
+
 ### Etherscan
 
 Etherscan provides a lot of detailed information about what's happening on Optimism.


### PR DESCRIPTION
Hey there - when looking for block explorers for Optimism, I found Alchemy's page useful as it provided code snippets and links to multiple popular ones, alongside respective information. The current Optimism article is limited as only has two options but this link will provide developers with more options.
