### PR TITLE
Update discord link for consistency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Optimism Community Hub
 
-[![Discord](https://img.shields.io/discord/667044843901681675.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discord.optimism.io/)
+[![Discord](https://img.shields.io/discord/667044843901681675.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discord.optimism.io)
 [![Twitter Follow](https://img.shields.io/twitter/follow/OptimismFND.svg?label=OptimismFND&style=social)](https://twitter.com/OptimismFND)
 
 Optimism is a Layer 2 platform for Ethereum.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Optimism Community Hub
 
-[![Discord](https://img.shields.io/discord/667044843901681675.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discord-gateway.optimism.io)
+[![Discord](https://img.shields.io/discord/667044843901681675.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discord.optimism.io/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/OptimismFND.svg?label=OptimismFND&style=social)](https://twitter.com/OptimismFND)
 
 Optimism is a Layer 2 platform for Ethereum.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This pull request updates the Discord link in the README.md file to be consistent with the Discord link within the optimism repository's README.md file (https://github.com/ethereum-optimism/optimism). This change improves consistency and reduces the risk of confusion for users.

**Tests**

Both Discord links (https://discord.optimism.io) (https://discord-gateway.optimism.io) direct to the same webpage.
