### PR TITLE
Remove incorrect info about pre-EIP-155 transactions on Optimism

### DIFF
--- a/src/docs/developers/build/differences.md
+++ b/src/docs/developers/build/differences.md
@@ -287,14 +287,6 @@ Optimism uses the same [JSON-RPC API](https://eth.wiki/json-rpc/API) as Ethereum
 Some additional Optimism specific methods have been introduced.
 See the full list of [custom JSON-RPC methods](./json-rpc.md) for more information.
 
-
-### Pre-EIP-155 support
-
-[Pre-EIP-155](https://eips.ethereum.org/EIPS/eip-155) transactions do not have a chain ID, which means a transaction on one Ethereum blockchain can be replayed on others.
-This is a security risk.
-Starting in November 2022, pre-EIP-155 transactions are no longer supported on Optimism.
-
-
 ## Transaction costs
 
 [Transaction costs on Optimism](./transaction-fees.md) include an [L2 execution fee](./transaction-fees.md#the-l2-execution-fee) and an [L1 data fee](./transaction-fees.md#the-l1-data-fee). 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

With pre-eip-155 Transactions:
We need to communicate clearly to developers in documentation that pre-EIP155 transactions should largely be avoided (and why), but also outline how to send pre-EIP155 transactions if desired. We do this in our documentation [here](https://community.optimism.io/docs/developers/build/differences/#pre-eip-155-support) already. I'm not sure why we had this seperate section saying that support is "removed" when it is actually not.

This was causing confusion with Base.
