### PR TITLE
fix: cast commands

### DIFF
--- a/src/docs/protocol/txn-flow.md
+++ b/src/docs/protocol/txn-flow.md
@@ -88,14 +88,14 @@ The directions here are for [Foundry](https://book.getfoundry.sh/), but the conc
    If the result is greater than the block number of the transaction, or equal, the transaction is finalized.
 
    ```sh
-   cast block finalized
+   cast block finalized --field number
    ```
 
 1. Get the number of the latest safe block.
    If the result is greater than the block number of the transaction, or equal, the transaction is safe.
 
    ```sh
-   cast block safe
+   cast block safe --field number
    ```
 
 1. If the transaction isn't finalized or safe, it's unsafe. 

--- a/src/docs/protocol/txn-flow.md
+++ b/src/docs/protocol/txn-flow.md
@@ -88,14 +88,14 @@ The directions here are for [Foundry](https://book.getfoundry.sh/), but the conc
    If the result is greater than the block number of the transaction, or equal, the transaction is finalized.
 
    ```sh
-   cast block finalized number
+   cast block finalized
    ```
 
 1. Get the number of the latest safe block.
    If the result is greater than the block number of the transaction, or equal, the transaction is safe.
 
    ```sh
-   cast block safe number
+   cast block safe
    ```
 
 1. If the transaction isn't finalized or safe, it's unsafe. 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

While testing out the OP devnet, I was unable to use the queries `cast block finalized number` and `cast block safe number`, as they returned errors. I have saved logs in this [Gist](https://gist.github.com/jcstein/678bba67617b8ce6e58413c87846af3b)

I found that removing `number` from the queries helped me send these queries successfully. Which can be seen in a [Gist](https://gist.github.com/jcstein/06ac479927131762269c0dbacd404ce2).

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
