### PR TITLE
Fix typos

### DIFF
--- a/src/docs/contribute/README.md
+++ b/src/docs/contribute/README.md
@@ -12,7 +12,7 @@ There are plenty of ways to contribute, in particular we appreciate support in t
 The Optimism codebase is maintained in a monorepo at [https://github.com/ethereum-optimism/optimism](https://github.com/ethereum-optimism/optimism). It's a [collection of packages](https://github.com/ethereum-optimism/optimism#directory-structure) all requiring different skills to maintain and evolve ranging from NodeJS and TypeScript, Solidity and EVM, Go and Geth to Docker and Kubernetes. The following are good entry points into using your coding skills to help us build Optimism:
 
 - Reporting issues. For security issues see [Security policy](https://github.com/ethereum-optimism/.github/blob/master/SECURITY.md).
-- Participate in the [Bug Bouty programme](https://immunefi.com/bounty/optimism/).
+- Participate in the [Bug Bounty programme](https://immunefi.com/bounty/optimism/).
 - Fixing and responding to existing issues. You can start off with those tagged ["good first issue"](https://github.com/ethereum-optimism/optimism/contribute) which are meant as introductory issues for external contributors.
   Contributions are rewarded with a cool [GitPOAP](https://www.gitpoap.io/gp/1035).
 - Work on open [bounties on Gitcoin](https://gitcoin.co/ethereum-optimism).

--- a/src/docs/developers/bedrock/differences.md
+++ b/src/docs/developers/bedrock/differences.md
@@ -205,7 +205,7 @@ Visualized, this flow looks like this:
 </div>
 
 By posting the proof upfront, it gives onchain monitoring tools enough time to detect a fraudulent withdrawal proof and attempt corrective action. 
-Regular users can do this monitoring too. For example, an exechange could halt withdrawals in the event of a fraudulent proof.
+Regular users can do this monitoring too. For example, an exchange could halt withdrawals in the event of a fraudulent proof.
 
 Since this change fundamentally changes the way withdrawals are handled, it is **not** backwards-compatible with the old network. If you are performing withdrawals outside our standard bridge interface, you will need to update your software. The easiest way to to do this is to use our [TypeScript SDK](https://github.com/ethereum-optimism/optimism/tree/develop/packages/sdk), which includes two-phase withdrawals support out of the box.
 
@@ -361,6 +361,6 @@ This section discusses some of the changes in Optimism internals.
 
 ### The transaction trail
 
-There is no longer a CTC (cannonical transaction chain) contract. Instead, L2 blocks are saved to the Ethereum blockchain using a non-contract address to minimize the L1 gas expenses. Please see the [Public Testnets](./public-testnets.md) page for more information on where to find batch submission addresses. 
+There is no longer a CTC (canonical transaction chain) contract. Instead, L2 blocks are saved to the Ethereum blockchain using a non-contract address to minimize the L1 gas expenses. Please see the [Public Testnets](./public-testnets.md) page for more information on where to find batch submission addresses. 
 
 [The block and transaction format is also different](https://github.com/ethereum-optimism/optimism/blob/develop/specs/rollup-node.md#l2-chain-derivation).

--- a/src/docs/developers/bedrock/explainer.md
+++ b/src/docs/developers/bedrock/explainer.md
@@ -120,7 +120,7 @@ Withdrawals are initiated on L2 via a call to the **Message Passer** predeploy c
 
 #### Two-step withdrawals
 
-Withdrawal proof validation bugs have been the root cause of many of the biggest bridge hacks of the last few years. The Bedrock release introduces an additional step in the withdrawals’ process of prior versions meant to provide an extra layer of defense against these types of bugs. In the two-step withdrawal process, a Merkle proof corresponding to the withdrawal must be submitted 7 days before the withdrawal can be finalized..  This new safety mechanism gives monitoring tools a full  7 days to find and detect invalid withdrawal proofs . If the [withdrawal](#withdrawals) proof is found to be invalid, a contract fix can be deployed before funds are lost. This dramatically reduces the risk of a bridge compromise.
+Withdrawal proof validation bugs have been the root cause of many of the biggest bridge hacks of the last few years. The Bedrock release introduces an additional step in the withdrawals’ process of prior versions meant to provide an extra layer of defense against these types of bugs. In the two-step withdrawal process, a Merkle proof corresponding to the withdrawal must be submitted 7 days before the withdrawal can be finalized. This new safety mechanism gives monitoring tools a full 7 days to find and detect invalid withdrawal proofs. If the [withdrawal](#withdrawals) proof is found to be invalid, a contract fix can be deployed before funds are lost. This dramatically reduces the risk of a bridge compromise.
 
 For full details, see the [withdrawals](https://github.com/ethereum-optimism/optimism/blob/develop/specs/withdrawals.md) section of the protocol specification.
 

--- a/src/docs/developers/build/run-a-node.md
+++ b/src/docs/developers/build/run-a-node.md
@@ -36,7 +36,7 @@ Prior to Bedrock you choose one of two configurations.
   Replicas gives you the most up to date information, at the cost of having to trust Optimism's updates.
 
 - **Verifiers** replicate from L1 (Ethereum).
-  Verifiers read and execute transactions from the cannonical block chain. 
+  Verifiers read and execute transactions from the canonical block chain. 
   As a result, the only way for them to have inaccurate information is an [Ethereum reorg](https://www.paradigm.xyz/2021/07/ethereum-reorgs-after-the-merge#post-merge-ethereum-with-proof-of-stake), an extremely rare event. 
 
 </details>

--- a/src/docs/governance/howto-delegate.md
+++ b/src/docs/governance/howto-delegate.md
@@ -82,5 +82,5 @@ Make sure you understand and follow the [delegate code of conduct](https://gov.o
 ## Step 4: Vote (if you are a delegate)
 
 Go to the [Optimism Governance Portal](https://vote.optimism.io/), connect your wallet, and vote.
-There is no minimum OP holding voting requirement, but you will need to have the OP tokens you wish to delegate or vote with in your wallet when the voting measurment is taken. 
+There is no minimum OP holding voting requirement, but you will need to have the OP tokens you wish to delegate or vote with in your wallet when the voting measurement is taken. 
 Tokens that are staked or LP’d at the time of measurement do not carry voting power.

--- a/src/docs/governance/token-house-history.md
+++ b/src/docs/governance/token-house-history.md
@@ -6,7 +6,7 @@ lang: en-US
 ## Seasons and voting cycles
 
 Token House governance operates on a seasonal schedule.
-Season three began on Janaury 26th, 2023, with Voting Cycle Ten.
+Season three began on January 26th, 2023, with Voting Cycle Ten.
 Seasons are separated with a Reflection Period. Reflection Periods may be followed by Special Voting Cycles to adopt proposals that come out of the previous Reflection Period.
 
 During each Season, Token House voting occurs via five-week voting cycles. 

--- a/src/docs/identity/build.md
+++ b/src/docs/identity/build.md
@@ -50,12 +50,12 @@ Here are some best practices to avoid violating users’ privacy:
 
 **Q: Are attestations replacements for verifiable credentials?**
 
-**A:** Atestations should not be viewed as a replacement for verifiable credentials or decentralized identifiers. Rather developers can use attestations to create [decentralized identifiers](https://www.w3.org/TR/did-core/), credentials, claims, and more.
+**A:** Attestations should not be viewed as a replacement for verifiable credentials or decentralized identifiers. Rather developers can use attestations to create [decentralized identifiers](https://www.w3.org/TR/did-core/), credentials, claims, and more.
 
 **Q: Are attestations replacements for proof of personhood?**
 
-**A:** Attestations and the associated web of trust are complementary with proof of personhood like [WorldID](https://worldcoin.org/blog/announcements/worldcoin-commits-optimism-superchain-vision-ahead-mainnet-launch) and similar solutions. Without proof of personhood, agents could sybil-attack the web of trust to build their reputation. On the otherhand web of trust extends proof of personhood to confer more information about the person you're interacting with which is critical in governance and other use-cases that require knowledge of the person's reputation.   
+**A:** Attestations and the associated web of trust are complementary with proof of personhood like [WorldID](https://worldcoin.org/blog/announcements/worldcoin-commits-optimism-superchain-vision-ahead-mainnet-launch) and similar solutions. Without proof of personhood, agents could sybil-attack the web of trust to build their reputation. On the other hand web of trust extends proof of personhood to confer more information about the person you're interacting with which is critical in governance and other use-cases that require knowledge of the person's reputation.   
 
 **Q: Why attestations instead of soulbound / non-transferable tokens?**
 
-**A:** Attestations have two key benefits over soulbound / non-transferable tokens: flexibility of whether the attestations is onchain or offchain and composability. While there is a cannonical [decentralized schema registry for attestations](https://optimism-goerli.easscan.org/schemas), there is no central registry or specification for soulbound / non-transferable tokens which can lead to poor interoperability between systems and protocols.
+**A:** Attestations have two key benefits over soulbound / non-transferable tokens: flexibility of whether the attestations is onchain or offchain and composability. While there is a canonical [decentralized schema registry for attestations](https://optimism-goerli.easscan.org/schemas), there is no central registry or specification for soulbound / non-transferable tokens which can lead to poor interoperability between systems and protocols.

--- a/src/docs/protocol/2-rollup-protocol.md
+++ b/src/docs/protocol/2-rollup-protocol.md
@@ -99,7 +99,7 @@ Transactions get to the sequencer in two ways:
    This provides Optimism with L1 Ethereum level censorship resistance.
    You can read more about this mechanism [is the protocol specifications](https://github.com/ethereum-optimism/optimism/blob/develop/specs/derivation.md#deriving-the-transaction-list).
 
-1. Transactions submitted directly to the sequnecer. 
+1. Transactions submitted directly to the sequencer. 
    These transactions are a lot cheaper to submit (because you do not need the expense of a separate L1 transaction), but of course they cannot be made censorship resistant, because the sequencer is the only entity that knows about them.
 
 </details>

--- a/src/docs/protocol/txn-flow.md
+++ b/src/docs/protocol/txn-flow.md
@@ -68,7 +68,7 @@ While the state after the transaction is subject to fault challenges, the transa
 :::
 
 You can see the code that builds the channels to be written to L1 in [`channel_out.go`](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/derive/channel_out.go) and [`channel_builder.go`](https://github.com/ethereum-optimism/optimism/blob/develop/op-batcher/batcher/channel_builder.go).
-The transasctions themselves are sent in [`op-batcher`'s main loop](https://github.com/ethereum-optimism/optimism/blob/915036aaa7eba7ee2ce290be90f78bb35df8d066/op-batcher/batcher/driver.go#L284-L299), which calls [`publishStateToL1`](https://github.com/ethereum-optimism/optimism/blob/915036aaa7eba7ee2ce290be90f78bb35df8d066/op-batcher/batcher/driver.go#L303-L344)
+The transactions themselves are sent in [`op-batcher`'s main loop](https://github.com/ethereum-optimism/optimism/blob/915036aaa7eba7ee2ce290be90f78bb35df8d066/op-batcher/batcher/driver.go#L284-L299), which calls [`publishStateToL1`](https://github.com/ethereum-optimism/optimism/blob/915036aaa7eba7ee2ce290be90f78bb35df8d066/op-batcher/batcher/driver.go#L303-L344)
 
 
 #### Determining the status of a transaction

--- a/src/docs/useful-tools/networks.md
+++ b/src/docs/useful-tools/networks.md
@@ -92,7 +92,7 @@ They are reproduced here for convenience
 
 <summary><b>Additional parameters</b></summary>
 
-These parameters are mostly useful to people responsible for running and administring network nodes.
+These parameters are mostly useful to people responsible for running and administering network nodes.
 
 | Parameter      | Value |
 | -------------- | ----- |

--- a/src/docs/useful-tools/oracles.md
+++ b/src/docs/useful-tools/oracles.md
@@ -59,7 +59,7 @@ You can always get up to date information (see, for example, [here (scroll down 
 
 The Tellor protocol can secure putting any verifiable data onchain, from spot price feeds, TWAPs, random numbers, to EVM calldata - you can even [specify your own "query type"](https://github.com/tellor-io/dataSpecs/issues/new?assignees=&labels=&template=new_query_type.yaml&title=%5BNew+Data+Request+Form%5D%3A+) to build a feed to fit your specific needs.
 
-As described in the oracles overview section of this page, we are an oracle protocol that has "a mechanism to reward entities that provide accurate information and penalize those that provide incorrect information." Therefore it is necessary to allow some reasonable [amount of time](https://docs.tellor.io/tellor/getting-data/solidity-integration#reading-data) between an oracle update and using that data, to allow for a potential dispute (probablistic finality).
+As described in the oracles overview section of this page, we are an oracle protocol that has "a mechanism to reward entities that provide accurate information and penalize those that provide incorrect information." Therefore it is necessary to allow some reasonable [amount of time](https://docs.tellor.io/tellor/getting-data/solidity-integration#reading-data) between an oracle update and using that data, to allow for a potential dispute (probabilistic finality).
 
 Tellor is a pull oracle where users fund (tip) a specific feed to get updated data reports and then read the data from our oracle contract, however under certain circumstances it can act similar to a push oracle; if your reading from a feed that is already being updated by others, or if you are [running your own data reporter.](https://docs.tellor.io/tellor/reporting-data/introduction)
 


### PR DESCRIPTION
**Description**

This PR fixes some typos across the site. I mainly detected the typos using the [cspell](https://cspell.org/) extension in VSCode and some manual review.