### PR TITLE
Update Optimism Spec Repository Link

### DIFF
--- a/src/docs/protocol/README.md
+++ b/src/docs/protocol/README.md
@@ -28,4 +28,4 @@ The first step to decentralizing the sequencer is to still have one sequencer at
 After this, the next step is to support multiple concurrent sequencers. This can be simply achieved by adopting a standard BFT consensus protocol, as used by other L1 protocols and sidechains like Polygon and Cosmos.
 
 
-You can keep up with the roadmap progress in [Cannon repository](https://github.com/ethereum-optimism/cannon/) for the fault proofs and [Optimism specs repository](https://github.com/ethereum-optimism/optimistic-specs) for the overall protocol work.
+You can keep up with the roadmap progress in [Cannon repository](https://github.com/ethereum-optimism/cannon/) for the fault proofs and [Optimism specs repository](https://github.com/ethereum-optimism/optimism/tree/develop/specs) for the overall protocol work.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Updating the Optimism Spec Repository from the archived version to its new home on the Optimism Monorepo.

**Tests**

n/a docs update

**Invariants**

n/a docs update

**Additional context**

n/a docs update

**Metadata**

- Fixes #[Link to Issue]

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
