### PR TITLE
Fix block storage address for mainnet

### DIFF
--- a/src/docs/protocol/2-rollup-protocol.md
+++ b/src/docs/protocol/2-rollup-protocol.md
@@ -21,7 +21,7 @@ In Optimism's case this parent blockchain is Ethereum.
 ## Block storage
 
 
-In Bedrock L2 blocks are saved to the Ethereum blockchain using a non-contract address ([`0xff00000000000000000000000000000000000420`](https://etherscan.io/address/0xff00000000000000000000000000000000000420)), to minimize the L1 gas expense.
+In Bedrock L2 blocks are saved to the Ethereum blockchain using a non-contract address ([`0xff00000000000000000000000000000000000010`](https://etherscan.io/address/0xff00000000000000000000000000000000000010)), to minimize the L1 gas expense.
 As these blocks are submitted as transaction calldata on Ethereum, there is no way to modify or censor them after the "transaction" is included in a block that has enough attestations.
 This is the way that Optimism inherits the availability and integrity guarantees of Ethereum.
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Block storage transactions are being sent to [0xff0...010](https://etherscan.io/address/0xff00000000000000000000000000000000000010) address instead of 0xff0...420 which is currently unused.
This pull request fixes the link in docs.