### PR TITLE
feat(networks): Fix the `op-node` link

### DIFF
--- a/src/docs/useful-tools/networks.md
+++ b/src/docs/useful-tools/networks.md
@@ -89,7 +89,7 @@ Links to download data directories will be posted here as soon as they are avail
   If you are running an archive only for post-bedrock transactions (using `op-geth` with the command line flag `gcmode=archive`), you do *not* need this file.
 - [Configuration parameters](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/deploy-config/mainnet.json).
 - [Latest release of `op-geth`](https://github.com/ethereum-optimism/op-geth/releases/latest)
-- [Latest release of `op-node`](https://github.com/ethereum-optimism/optimism/releases/latest)
+- [Latest release of `op-node`](https://github.com/ethereum-optimism/optimism/releases/) - you need to scroll down until you get a release that has `op-node` in it.
 - [Legacy geth](https://hub.docker.com/layers/ethereumoptimism/l2geth/0.5.31/images/sha256-5577036dc36d167d11f5ac49b91cc0a3d835574928a9563783c2e70309e5eb28?context=explore).
   
 
@@ -182,7 +182,7 @@ These parameters are mostly useful to people responsible for running and adminis
   If you are running an archive only for post-bedrock transactions (using `op-geth` with the command line flag `gcmode=archive`), you do *not* need this file.
 - [Configuration parameters](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/deploy-config/goerli.json)
 - [Latest releases of `op-geth`](https://github.com/ethereum-optimism/op-geth/releases/latest)
-- [Latest releases of `op-node`](https://github.com/ethereum-optimism/optimism/releases/latest)
+- [Latest release of `op-node`](https://github.com/ethereum-optimism/optimism/releases/) - you need to scroll down until you get a release that has `op-node` in it.
 - [Legacy geth](https://hub.docker.com/layers/ethereumoptimism/l2geth/0.5.31/images/sha256-5577036dc36d167d11f5ac49b91cc0a3d835574928a9563783c2e70309e5eb28?context=explore)
 
 (1) This file is compressed with `zstd`. 


### PR DESCRIPTION
The existing link only worked until a different package was released from the monorepo.