### PR TITLE
updating blockscout urls

### DIFF
--- a/src/docs/useful-tools/debugging.md
+++ b/src/docs/useful-tools/debugging.md
@@ -20,7 +20,7 @@ You can see more information about all the L2 features Etherscan offers on our [
 
 ## Blockscout
 
-Blockscout allows you to see events on both [OP Mainnet](https://blockscout.com/optimism/mainnet) and [OP Goerli](https://blockscout.com/optimism/goerli).
+Blockscout allows you to see events on both [OP Mainnet](https://optimism.blockscout.com) and [OP Goerli](https://optimism-goerli.blockscout.com).
 
 ## Know other good tools?
 

--- a/src/docs/useful-tools/explorers.md
+++ b/src/docs/useful-tools/explorers.md
@@ -5,10 +5,10 @@ lang: en-US
 
 ## Blockscout
 
-We have a Blockscout explorer for both [OP Mainnet](https://blockscout.com/optimism/mainnet/) and [OP Goerli](https://blockscout.com/optimism/goerli/). It includes:
+We have a Blockscout explorer for both [OP Mainnet](https://optimism.blockscout.com) and [OP Goerli](https://optimism-goerli.blockscout.com). It includes:
 
-- [Verified contract source code, along with the ability to interact with it](https://blockscout.com/optimism/goerli/address/0x106941459A8768f5A92b770e280555FAF817576f/contracts#address-tabs)
-- [Detailed transaction information](https://blockscout.com/optimism/goerli/tx/0xeb98c8279983cfee472c6067d2405acc130dca37e7536d6c83930e29aaa40e3e)
+- [Verified testnet contract source code, along with the ability to interact with it](https://optimism-goerli.blockscout.com/verified-contracts)
+- [Detailed testnet transaction information](https://optimism-goerli.blockscout.com/txs)
 
 
 

--- a/src/docs/useful-tools/monitoring.md
+++ b/src/docs/useful-tools/monitoring.md
@@ -24,7 +24,7 @@ Check out the [OP Mainnet explorer](https://explorer.optimism.io) as well as the
 
 ### Blockscout
 
-Another block explorer for [OP Mainnet](https://blockscout.com/optimism/mainnet) and [OP Goerli](https://blockscout.com/optimism/goerli) is [Blockscout](https://blockscout.com).
+Another block explorer for [OP Mainnet](https://optimism.blockscout.com) and [OP Goerli](https://optimism-goerli.blockscout.com) is [Blockscout](https://blockscout.com).
 
 
 ## Dashboards on Dune Analytics


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Blockscout just released v5.2.0. This is a new UI and a new URL for their explorer.

**Tests**

n/a documentation update

**Additional context**

I added clarification on `src/docs/useful-tools/explorers.md` that they have verified contract source code, the ability to interact with it and tx information on _testnet_. The op mainnet links are not showing errors.

**Metadata**

- Fixes DEVRL-1013
