### PR TITLE
removing extra datadir flag

### DIFF
--- a/src/docs/developers/build/run-a-node.md
+++ b/src/docs/developers/build/run-a-node.md
@@ -155,7 +155,6 @@ cd ~/op-geth
   --authrpc.jwtsecret=./jwt.txt \
   --authrpc.port=8551 \
   --authrpc.vhosts="*" \
-  --datadir=/data \
   --verbosity=3 \
   --rollup.disabletxpoolgossip=true \
   --nodiscover \


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The [Running an OP Mainnet or testnet - Scripts to start the different components](https://community.optimism.io/docs/developers/build/run-a-node/#scripts-to-start-the-different-components) had two `--datadir` flags specified. In the instructions above, it tells the user to make a `datadir` directory in the root directory of `op-geth`. I left the flag that points to this directory that the user has made before this step.

**Tests**

n/a

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
