### PR TITLE
fix(run-a-node): Remove p2p.disable CLI option

### DIFF
--- a/src/docs/developers/build/run-a-node.md
+++ b/src/docs/developers/build/run-a-node.md
@@ -181,7 +181,6 @@ cd ~/optimism/op-node
         --network=goerli \
         --rpc.addr=0.0.0.0 \
         --rpc.port=8547 \
-        --p2p.disable \
         --l1= << URL TO L1 >>       
 ```        
 


### PR DESCRIPTION
**Description**

The vast majority of users should leave P2P enabled so unsafe blocks can be received instead of waiting for batches to be published to L1.
