### PR TITLE
Update node-operator-guide.md

### DIFF
--- a/src/docs/developers/bedrock/node-operator-guide.md
+++ b/src/docs/developers/bedrock/node-operator-guide.md
@@ -163,7 +163,7 @@ A minimal valid configuration for a rollup node on our `beta-1` testnet looks li
 ```bash
 op-node --l1=<goerli RPC url> \
         --l2=<op-geth authenticated RPC url> \
-        --network=beta-1
+        --network=beta-1 \
         --rpc.addr=127.0.0.1 \
         --rpc.port=9545 \
         --l2.jwt-secret=<path to JWT secret>


### PR DESCRIPTION
**Description**

Add missing `\` character to op-node execution commands.
Line 284 remains unchanged, but is printed in the diff list. 🤔 

**Tests**

None.

**Additional context**

None.

**Metadata**

None.
