### PR TITLE
removing references to old forms and adding updated form links

### DIFF
--- a/src/.vuepress/theme/components/Anchor.js
+++ b/src/.vuepress/theme/components/Anchor.js
@@ -63,7 +63,7 @@ export default Vue.extend({
                                     " Discord community"
                                 ])
                             ]),
-                            h("a", { attrs: { href: "https://forms.monday.com/forms/c867f3f357707ff1fb4af0d3d5080710?r=use1", target: "_blank" } }, [
+                            h("a", { attrs: { href: "https://airtable.com/appQ2S9IatldkoNQw/shr2e75GnXRqi6yTM", target: "_blank" } }, [
                                 h("div", [
                                     h("i", { attrs: { class: "far fa-comment-dots" } }),
                                     " Get support for going live"

--- a/src/.vuepress/theme/components/PageMeta.vue
+++ b/src/.vuepress/theme/components/PageMeta.vue
@@ -33,7 +33,7 @@
             </a>
           </li>
           <li>
-            <a href="https://forms.monday.com/forms/c867f3f357707ff1fb4af0d3d5080710?r=use1" target="_blank" rel="noopener noreferrer">
+            <a href="https://airtable.com/appQ2S9IatldkoNQw/shr2e75GnXRqi6yTM" target="_blank" rel="noopener noreferrer">
               <i class="far fa-comment-dots"></i> Get support for going live
             </a>
           </li>

--- a/src/docs/biz/README.md
+++ b/src/docs/biz/README.md
@@ -5,7 +5,7 @@ lang: en-US
 
 Welcome! We're stoked that you're launching on OP Mainnet. 
 
-If you have not filled out the [get started form](https://forms.monday.com/forms/c867f3f357707ff1fb4af0d3d5080710) please do so prior to reading this.
+If you have not filled out the [connect with OPLabs form](https://airtable.com/appQ2S9IatldkoNQw/shr2e75GnXRqi6yTM) please do so prior to reading this.
 
 We are excited for your deployment onto OP Mainnet! 
 You will be welcomed by [the following metrics](https://dune.com/optimismfnd/Optimism) 📈📈 (up and to the right!), [a budding community](https://discord-gateway.optimism.io/) 🫂🫂, and some great exclusive [Telegram Channels](https://t.me/+Cb7q0a1YqItkZTRk) ⚙️⚙️ for builders.
@@ -22,13 +22,12 @@ Steps to take if you would like developer support immediately, ranked in order o
 1. See our [Developer Documentation](../developers/), [Tutorials](https://github.com/ethereum-optimism/optimism-tutorial), and [Help Center](https://help.optimism.io)
 1. Head over to [**#dev-support**](https://discord.com/channels/667044843901681675/887914409207414785) on discord for the fastest help 
 1. Join [this TG group](https://t.me/+Cb7q0a1YqItkZTRk) and ask for help there
-1. Last attempt: [Fill out this form](https://forms.monday.com/forms/c867f3f357707ff1fb4af0d3d5080710).
 
 
 ## Marketing Requests 🦸🦸
 
 When your project is deployed on OP Mainnet, you can be added to [our ecosystem page](https://www.optimism.io/apps/all). 
-Simply [fill out this form](https://oplabs.typeform.com/op-marketing) to be included. Inclusion is at our discretion. 
+Simply [fill out this form](https://airtable.com/appQ2S9IatldkoNQw/shrIqJsv2nyBUo6Ka) to be included. Inclusion is at our discretion. 
 We add new projects live on OP Mainnet [here](https://www.optimism.io/apps/all) once a week.
 
 

--- a/src/docs/governance/airdrop-1.md
+++ b/src/docs/governance/airdrop-1.md
@@ -140,7 +140,6 @@ The [Airdrop #1 Allocations](#airdrop-1-allocations) table above has been update
 For a list of excluded sybil addresses, [see this spreadsheet](https://docs.google.com/spreadsheets/d/1kUAt-vrkID0yBkic72djWRxdliK8W_5rBGxq6-Iv3cg).
 
 In the interest of maintaining the integrity of future OP Airdrops, we will not be publishing the additional filters used to remove these addresses.
-If you have feedback about this additional sybil filtering process, please feel free to [fill out this feedback form](https://oplabs.typeform.com/sybil-feedback).
 
 ## What’s Next?
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Updating Public facing Marketing & Inbound links

**Additional context**

I removed one form link for suggestions on sybil resistance suggestions in the airdrop page. Our updated forms don't fit here.

**Metadata**

- Fixes #DEVRL-1133
