### PR TITLE
Fix duplicated datadir in "Running an OP Mainnet or testnet node"

### DIFF
--- a/src/docs/developers/build/run-a-node.md
+++ b/src/docs/developers/build/run-a-node.md
@@ -163,13 +163,12 @@ cd ~/op-geth
   --authrpc.jwtsecret=./jwt.txt \
   --authrpc.port=8551 \
   --authrpc.vhosts="*" \
-  --datadir=/data \
   --verbosity=3 \
   --rollup.sequencerhttp=$SEQUENCER_URL \
   --nodiscover \
   --syncmode=full \
   --maxpeers=0 \
-  --datadir ./datadir \
+  --datadir=./datadir \
   --snapshot=false
 ```
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

<img width="390" alt="image" src="https://github.com/ethereum-optimism/community-hub/assets/4103490/d396c4e5-fe6e-4392-b671-1ec32e675030">

Currently, datadir flag is duplicated in the document. The correct one is ./datadir as per prior steps.

**Tests**

No test needed for a simple document change

**Additional context**

https://community.optimism.io/docs/developers/build/run-a-node/#
