### PR TITLE
fix: script to estimate sync time by updating foundry command flag

### DIFF
--- a/src/docs/developers/build/run-a-node.md
+++ b/src/docs/developers/build/run-a-node.md
@@ -252,7 +252,7 @@ For OP Mainnet substitute `https://mainnet.optimism.io`
 #! /usr/bin/bash
 
 export ETH_RPC_URL=http://localhost:8545
-T0=`cast block latest number` ; sleep 60 ; T1=`cast block latest number`
+T0=`cast block latest -f number` ; sleep 60 ; T1=`cast block latest -f number`
 PER_MIN=`expr $T1 - $T0`
 echo Blocks per minute: $PER_MIN
 
@@ -268,7 +268,7 @@ echo Progress per minute: $PROGRESS_PER_MIN
 
 
 # How many more blocks do we need?
-HEAD=`cast block --rpc-url https://goerli.optimism.io latest number`
+HEAD=`cast block --rpc-url https://goerli.optimism.io latest -f number`
 BEHIND=`expr $HEAD - $T1` 
 MINUTES=`expr $BEHIND / $PROGRESS_PER_MIN`
 HOURS=`expr $MINUTES / 60`


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The script does not run with the latest version of Foundry cast. Gives error:
```
error: unexpected argument 'number' found

Usage: cast block [OPTIONS] [BLOCK]

For more information, try '--help'.
```

**Tests**

I tested it locally

**Additional context**

Foundry `cast` `v0.2.0` is the latest version and here is the command --help
```
johns@ubu-g15:~/dev/superhack$ cast -V
cast 0.2.0 (1a110a5 2023-08-08T16:26:45.991437018Z)
johns@ubu-g15:~/dev/superhack$ cast block --help
Get information about a block

Usage: cast block [OPTIONS] [BLOCK]

Arguments:
  [BLOCK]
          The block height to query at.
          
          Can also be the tags earliest, finalized, safe, latest, or pending.

Options:
  -f, --field <FIELD>
          If specified, only get the given field of the block

      --full
          [env: CAST_FULL_BLOCK=]

  -r, --rpc-url <URL>
          The RPC endpoint
          
          [env: ETH_RPC_URL=http://localhost:8545]

      --flashbots
          Use the Flashbots RPC URL (https://rpc.flashbots.net)

  -h, --help
          Print help (see a summary with '-h')

Display options:
  -j, --json
          Print the block as JSON
```

**Metadata**

None, should I make an issue?
