### PR TITLE
removing the latest keyword

### DIFF
--- a/src/docs/developers/build/json-rpc.md
+++ b/src/docs/developers/build/json-rpc.md
@@ -21,7 +21,7 @@ This method is documented in [the specifications](https://github.com/ethereum-op
 
 ```sh
 curl -X POST -H "Content-Type: application/json" --data  \
-   '{"jsonrpc":"2.0","method":"optimism_outputAtBlock","params":["latest"],"id":1}' \
+   '{"jsonrpc":"2.0","method":"optimism_outputAtBlock","params":["<block_number>"],"id":1}' \
    http://localhost:9545
 ```
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Removing the `latest` keyword and replacing it with block_number. 

**Tests**

n/a

**Additional context**

These keywords are not supported in this rpc call.

**Metadata**

- Fixes https://github.com/ethereum-optimism/developer-support/issues/82
