### PR TITLE
fix sync status script

### DIFF
--- a/src/docs/developers/build/run-a-node.md
+++ b/src/docs/developers/build/run-a-node.md
@@ -275,10 +275,10 @@ For OP Mainnet substitute `https://mainnet.optimism.io`
 For OP Goerli substitute `https://goerli.optimism.io`
 
 ```sh
-#! /usr/bin/bash
+#!/bin/bash
 
 export ETH_RPC_URL=http://localhost:8545
-T0=`cast block latest number` ; sleep 60 ; T1=`cast block latest number`
+T0=`cast block latest -f number` ; sleep 60 ; T1=`cast block latest -f number`
 PER_MIN=`expr $T1 - $T0`
 echo Blocks per minute: $PER_MIN
 
@@ -294,7 +294,7 @@ echo Progress per minute: $PROGRESS_PER_MIN
 
 
 # How many more blocks do we need?
-HEAD=`cast block --rpc-url https://sepolia.optimism.io latest number`
+HEAD=`cast block --rpc-url https://sepolia.optimism.io latest -f number`
 BEHIND=`expr $HEAD - $T1` 
 MINUTES=`expr $BEHIND / $PROGRESS_PER_MIN`
 HOURS=`expr $MINUTES / 60`


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
- When copying the script it wont work, because `cast` has changed the params, and needs the flag `-f` to get the number.
- Also changed the shebang path, since it wasn't working as expected

**Tests**
- no tests have been added, just ran locally.

**Additional context**
N/A

**Metadata**

- Fixes #[Link to Issue]
