### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-*       @Nicca42 @smartcontracts @OPMattie @sbvegan
-
-
+*       @Nicca42 @smartcontracts @OPMattie @sbvegan @cpengilly


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

As our new Technical Content Lead, I think Cythina should be a code owner.

**Tests**

n/a

**Additional context**

Mattie will also be out of office for a couple weeks so we need someone else to make approvals.

**Metadata**

- Fixes #[Link to Issue]
