### PR TITLE
Fix speed test script to be compatible with latest foundry

### DIFF
--- a/src/docs/developers/build/run-a-node.md
+++ b/src/docs/developers/build/run-a-node.md
@@ -296,7 +296,7 @@ echo Progress per minute: $PROGRESS_PER_MIN
 
 # How many more blocks do we need?
 HEAD=`cast block-number --rpc-url $REF_RPC_URL`
-BEHIND=`expr $HEAD - $T1` 
+BEHIND=`expr $HEAD - $T1`
 MINUTES=`expr $BEHIND / $PROGRESS_PER_MIN`
 HOURS=`expr $MINUTES / 60`
 echo Hours until sync completed: $HOURS

--- a/src/docs/developers/build/run-a-node.md
+++ b/src/docs/developers/build/run-a-node.md
@@ -272,18 +272,18 @@ INFO [06-26|14:02:12.982] Starting work on payload                 id=0x5542117d
 
 To estimate how long the synchronization will take, you need to first find out how many blocks you synchronize in a minute. 
 
-You can use this script, which uses [Foundry](https://book.getfoundry.sh/). and the UNIX Note that this script is for OP Sepolia. 
-For OP Mainnet substitute `https://mainnet.optimism.io`
-For OP Goerli substitute `https://goerli.optimism.io`
+You can use this script, which uses [Foundry](https://book.getfoundry.sh/). and the UNIX Note that this script is for OP Sepolia.
+For OP Mainnet substitute `REF_RPC_URL=https://mainnet.optimism.io`
+For OP Goerli substitute `REF_RPC_URL=https://goerli.optimism.io`
 
 ```sh
 #! /usr/bin/bash
 
-export ETH_RPC_URL=http://localhost:8545
-T0=`cast block latest number` ; sleep 60 ; T1=`cast block latest number`
+export REF_RPC_URL=https://sepolia.optimism.io
+
+T0=`cast block-number` ; sleep 60 ; T1=`cast block-number`
 PER_MIN=`expr $T1 - $T0`
 echo Blocks per minute: $PER_MIN
-
 
 if [ $PER_MIN -eq 0 ]; then
     echo Not synching
@@ -294,9 +294,8 @@ fi
 PROGRESS_PER_MIN=`expr $PER_MIN - 30`
 echo Progress per minute: $PROGRESS_PER_MIN
 
-
 # How many more blocks do we need?
-HEAD=`cast block --rpc-url https://sepolia.optimism.io latest number`
+HEAD=`cast block-number --rpc-url $REF_RPC_URL`
 BEHIND=`expr $HEAD - $T1` 
 MINUTES=`expr $BEHIND / $PROGRESS_PER_MIN`
 HOURS=`expr $MINUTES / 60`

--- a/src/docs/developers/build/run-a-node.md
+++ b/src/docs/developers/build/run-a-node.md
@@ -272,18 +272,34 @@ INFO [06-26|14:02:12.982] Starting work on payload                 id=0x5542117d
 
 To estimate how long the synchronization will take, you need to first find out how many blocks you synchronize in a minute. 
 
-You can use this script, which uses [Foundry](https://book.getfoundry.sh/). and the UNIX Note that this script is for OP Sepolia.
-For OP Mainnet substitute `REF_RPC_URL=https://mainnet.optimism.io`
-For OP Goerli substitute `REF_RPC_URL=https://goerli.optimism.io`
+You can use this [Foundry](https://book.getfoundry.sh/) script to get an estimated sync time.
 
 ```sh
-#! /usr/bin/bash
+#!/usr/bin/bash
 
-export REF_RPC_URL=https://sepolia.optimism.io
+export ETH_RPC_URL=http://localhost:8545
+CHAIN_ID=`cast chain-id`
+echo Chain ID: $CHAIN_ID
+echo Please wait
 
-T0=`cast block-number` ; sleep 60 ; T1=`cast block-number`
+if [ $CHAIN_ID -eq 10 ]; then
+  L2_URL=https://mainnet.optimism.io
+fi
+
+
+if [ $CHAIN_ID -eq 420 ]; then
+  L2_URL=https://goerli.optimism.io
+fi
+
+
+if [ $CHAIN_ID -eq 11155420 ]; then
+  L2_URL=https://sepolia.optimism.io
+fi
+
+T0=`cast block-number --rpc-url $ETH_RPC_URL` ; sleep 60 ; T1=`cast block-number --rpc-url $ETH_RPC_URL`
 PER_MIN=`expr $T1 - $T0`
 echo Blocks per minute: $PER_MIN
+
 
 if [ $PER_MIN -eq 0 ]; then
     echo Not synching
@@ -294,8 +310,9 @@ fi
 PROGRESS_PER_MIN=`expr $PER_MIN - 30`
 echo Progress per minute: $PROGRESS_PER_MIN
 
+
 # How many more blocks do we need?
-HEAD=`cast block-number --rpc-url $REF_RPC_URL`
+HEAD=`cast block-number --rpc-url $L2_URL`
 BEHIND=`expr $HEAD - $T1`
 MINUTES=`expr $BEHIND / $PROGRESS_PER_MIN`
 HOURS=`expr $MINUTES / 60`


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

I have run this script with the latest version of Foundry and got an error.

```
error: unexpected argument 'number' found
```

And I found that ETH_RPC_URL is not used.

So, I propose a fix to the above problems.

**Additional context**

cast 0.2.0 (ae89c92 2023-09-15T00:16:50.567420396Z)
