### PR TITLE
Remove outdated Airdrop #1 notice

### DIFF
--- a/src/docs/governance/economics.md
+++ b/src/docs/governance/economics.md
@@ -3,13 +3,6 @@ title: OP Economics
 lang: en-US
 ---
 
-::: tip Notice: OP Airdrop #1 is now available to claim
-[Click here to claim](https://app.optimism.io/airdrop/check)
-
-*Airdrop #1 does not require payment.*
-*Stay safe!*
-:::
-
 The Optimism Collective is based on the idea that healthy public goods create a thriving and valuable ecosystem. 
 The economics of this ecosystem are designed to generate value for three constituencies:
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

There is a notice in the OP Economics page saying that "OP Airdrop #1 is now available to claim". This information is however no longer correct since unclaimed OP from Airdrop 1 was sent directly to addresses eligible to claim on Sep 15.

This PR removes the section with the outdated information.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
