### PR TITLE
Remove link to Discord channel that is no longer used

### DIFF
--- a/src/docs/governance/existing-delegate.md
+++ b/src/docs/governance/existing-delegate.md
@@ -9,7 +9,6 @@ As a delegate, you should:
 
 - Join the conversation in the below channels in our [Discord](https://discord-gateway.optimism.io/):
   - [#gov-general](https://discord.com/channels/667044843901681675/968498307913637919): This channel is for general governance discussions.
-  - [#token-house-gov](https://discord.com/channels/667044843901681675/991340698995544176): This announcement channel will help you keep up to date with big events in the governance process, such as when voting starts, meta-governance updates, etc
   - [#grants](https://discord.com/channels/667044843901681675/1069653708369047623): This channel is for discussion about the grants process and for delegates to provide feedback to grant applicants
   - [#delegate-discussion](https://discord.com/channels/667044843901681675/989611992295813241): If you are a delegate with more than 0.5% delegated voting power, join the conversation with other larger delegates to discuss proposals & the governance process.
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR deletes a link to the unused # token-house-gov channel on Discord. The last post there was published in January and announced the beginning of Season 3.

Since this channel is no longer used, it is misleading to link to it and suggest that it will "help you keep up to date".

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
