### PR TITLE
Update link to code of conduct, outdated info

### DIFF
--- a/src/docs/governance/delegate.md
+++ b/src/docs/governance/delegate.md
@@ -9,8 +9,8 @@ For this reason, people are able to delegate their OP to community members who h
 
 Being a delegate is an important job that comes with a lot of responsibility. Therefore, before deciding to become a delegate, you should be familiar with:
 
-* The [Working Constitution](https://gov.optimism.io/t/working-constitution-of-the-optimism-collective/55).
-* The [Operating Manual](https://github.com/ethereum-optimism/OPerating-manual/blob/main/manual.md).
+* The [Working Constitution](https://gov.optimism.io/t/working-constitution-of-the-optimism-collective/55)
+* The [Operating Manual](https://github.com/ethereum-optimism/OPerating-manual/blob/main/manual.md)
 * The [Code of Conduct](https://gov.optimism.io/t/code-of-conduct/5751)
 
 

--- a/src/docs/governance/delegate.md
+++ b/src/docs/governance/delegate.md
@@ -11,7 +11,7 @@ Being a delegate is an important job that comes with a lot of responsibility. Th
 
 * The [Working Constitution](https://gov.optimism.io/t/working-constitution-of-the-optimism-collective/55).
 * The [Operating Manual](https://github.com/ethereum-optimism/OPerating-manual/blob/main/manual.md).
-* The [Delegate Code of Conduct](https://gov.optimism.io/t/delegate-code-of-conduct/3943)
+* The [Code of Conduct](https://gov.optimism.io/t/code-of-conduct/5751)
 
 
 ## Ready to be a delegate?

--- a/src/docs/governance/existing-delegate.md
+++ b/src/docs/governance/existing-delegate.md
@@ -13,7 +13,7 @@ As a delegate, you should:
   - [#delegate-discussion](https://discord.com/channels/667044843901681675/989611992295813241): If you are a delegate with more than 0.5% delegated voting power, join the conversation with other larger delegates to discuss proposals & the governance process.
 
 - Provide feedback on draft proposals in the [Proposals Discussion](https://gov.optimism.io/c/proposals/38) section of the Forum
-     - If you have more than 0.5% of voting supply then you can also approve non-grant proposals.
+     - If you have more than 0.25% of voting supply then you can also approve non-grant proposals.
        Non-grant proposals need at least 4 approvals to move to a vote. 
        To approve a proposal post this phrase in a forum comment on Discourse:
        > **I am an Optimism delegate with sufficient voting power and I believe this proposal is ready to move to a vote.**

--- a/src/docs/governance/existing-delegate.md
+++ b/src/docs/governance/existing-delegate.md
@@ -10,7 +10,7 @@ As a delegate, you should:
 - Join the conversation in the below channels in our [Discord](https://discord-gateway.optimism.io/):
   - [#gov-general](https://discord.com/channels/667044843901681675/968498307913637919): This channel is for general governance discussions.
   - [#grants](https://discord.com/channels/667044843901681675/1069653708369047623): This channel is for discussion about the grants process and for delegates to provide feedback to grant applicants
-  - [#delegate-discussion](https://discord.com/channels/667044843901681675/989611992295813241): If you are a delegate with more than 0.5% delegated voting power, join the conversation with other larger delegates to discuss proposals & the governance process.
+  - [#delegate-discussion](https://discord.com/channels/667044843901681675/989611992295813241): If you are a delegate with more than 0.25% delegated voting power, join the conversation with other larger delegates to discuss proposals & the governance process.
 
 - Provide feedback on draft proposals in the [Proposals Discussion](https://gov.optimism.io/c/proposals/38) section of the Forum
      - If you have more than 0.25% of voting supply then you can also approve non-grant proposals.

--- a/src/docs/governance/howto-delegate.md
+++ b/src/docs/governance/howto-delegate.md
@@ -74,7 +74,7 @@ Comment on the [Forum](https://gov.optimism.io/) and provide feedback on proposa
 
 ::: tip        
              
-Make sure you understand and follow the [delegate code of conduct](https://gov.optimism.io/t/delegate-code-of-conduct/3943)
+Make sure you understand and follow the [code of conduct](https://gov.optimism.io/t/code-of-conduct/5751)
 
 :::
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

- On the "existing delegate" page it says that if "you have more than 0.5% of voting supply then you can also approve non-grant proposals." --> this is however no longer correct, since the number was lowered to 0.25% (see Operating Manual).
- Changed links that currently go to the deprecated delegate code of conduct. Those links now go to the new code of conduct.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
