### PR TITLE
Update providers with Change name case

### DIFF
--- a/src/docs/useful-tools/providers.md
+++ b/src/docs/useful-tools/providers.md
@@ -47,11 +47,11 @@ On the platform, there are also [Public APIs](https://blastapi.io/public-api/opt
 - OP Goerli
 
 
-## Blockpi
+## BlockPI
 
 ### Description and Pricing
 
-[Blockpi](https://blockpi.io/) Network ships scalable, high performance and globally distributed infrastructure with the most flexible and developer-first pricing in the industry. Build from scratch all the way to enterprise without monthly subscription. Register at [dashboard](https://dashboard.blockpi.io/) and get Free 100M RU every month!
+[BlockPI](https://blockpi.io/) Network ships scalable, high performance and globally distributed infrastructure with the most flexible and developer-first pricing in the industry. Build from scratch all the way to enterprise without monthly subscription. Register at [dashboard](https://dashboard.blockpi.io/) and get Free 100M RU every month!
 
 ### Supported Networks
 


### PR DESCRIPTION
Description

BlockPI is a mainstream RPC provider, handling nearly 1 billion RPC requests per day. OP's RPC requests have a significant proportion. I believe we are qualified to be included in this document. Thanks!

Tests

Just simply adding BlockPI in the RPC provider list.

Additional context

None

Metadata

Fixes #[Link to Issue] None