### PR TITLE
update-node-api-providers-add-1RPC-support

### DIFF
--- a/src/docs/useful-tools/providers.md
+++ b/src/docs/useful-tools/providers.md
@@ -178,3 +178,12 @@ The URL format is `https://optimism.nownodes.io/?API_key=<API key from NOWNodes`
 
 - OP Mainnet
 - OP Goerli
+
+  ## 1RPC
+
+### Description and Pricing
+[1RPC](https://1rpc.io/) is the first and only on-chain attested privacy preserving RPC that eradicate metadata exposure and leakage when interacting with blockchains.
+
+### Supported Networks
+
+- OP Mainnet


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adding 1RPC to Optimism Docs. 1RPC has relayed over 1.8 billion requests on Optimism. 

https://docs.1rpc.io/overview/supported-networks

**Tests**

We have tested in local environment and RPC is now live. 

**Additional context**

Protecting users' privacy during blockchain interactions, with our free RPC relay.

**Metadata**

- Fixes #[Link to Issue]
