### PR TITLE
Add handling for "noncalldata_gas" to the L1 data fee calculation

### DIFF
--- a/src/docs/developers/build/transaction-fees.md
+++ b/src/docs/developers/build/transaction-fees.md
@@ -83,7 +83,7 @@ This fee is based on four factors:
 Here's the math:
 
 ```
-l1_data_fee = l1_gas_price * (tx_data_gas + fixed_overhead) * dynamic_overhead
+l1_data_fee = l1_gas_price * (tx_data_gas + fixed_overhead + noncalldata_gas) * dynamic_overhead
 ```
 
 Where `tx_data_gas` is:


### PR DESCRIPTION
Re-Add `noncalldata_gas` given feedback from teams trying to estimate.

Open to how this should best be calculated, since the current formula will understate the actual l1_gas_used field.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A clear and concise description of the features you're adding in this pull request.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
