### PR TITLE
Update NERD-req.md

### DIFF
--- a/src/docs/contribute/contribution-path/NERD-req.md
+++ b/src/docs/contribute/contribution-path/NERD-req.md
@@ -39,9 +39,9 @@ The journey to become an supNERD follow the following steps:
 
 **To ensure that our support NERDs are only the highest quality nerds we have the following requirements before you can start a NERD trial**
 
-1. Fill in the [wannabe-NERD form](https://optimismpbc.typeform.com/become-a-nerd).
+1. Fill in the [wannabe-NERD form](https://forms.gle/YCirMCzagW64BNLu7).
     This helps us know all our NERDs and their languages. L2 is global after all 🌍🌎🌏
-    [NERDs](https://optimismpbc.typeform.com/become-a-nerd)
+    [NERDs](https://forms.gle/YCirMCzagW64BNLu7)
 1. Be in the Optimism Discord for at least 2 months.
     We need to know you are serious 👀
 1.  Be actively offering support in the Discord for at least 2 months. 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

Describe the bug
broken links on the website. When the user clicked on the 'wannabe-NERD form' link on the path https://community.optimism.io/docs/contribute/contribution-path/nerd-req/#becoming-a-supnerd the link was 'blank or not displayed' instead of the expected contact page..

To Reproduce
Steps to reproduce the behavior:

Go to 'https://community.optimism.io/docs/contribute/contribution-path/nerd-req/#becoming-a-supnerd'
Click on 'wannabe-NERD form'
Scroll down to 'The form does not display'
See error
Expected behavior
Hoping to fix it to sync with the discord form


Additional context
The correct link is this if the form is still active for the reviewer 'https://forms.gle/YCirMCzagW64BNLu7'