### PR TITLE
deployment contracts url fix

### DIFF
--- a/src/docs/developers/bridge/messaging.md
+++ b/src/docs/developers/bridge/messaging.md
@@ -122,7 +122,7 @@ contract MyOtherContract {
 
 ::: tip Using the messenger contracts
 Our messenger contracts, the [`L1CrossDomainMessenger`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol) and [`L2CrossDomainMessenger`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol), always come pre-deployed to each of our networks.
-You can find the exact addresses of these contracts on our various deployments [inside of the Optimism monorepo](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts/deployments).
+You can find the exact addresses of these contracts on our various deployments [inside of the Optimism monorepo](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock/deployments).
 :::
 
 ## Communication speed

--- a/src/docs/useful-tools/networks.md
+++ b/src/docs/useful-tools/networks.md
@@ -18,8 +18,8 @@ Such RPCs are either totally unsupported, or will return nonsensical values.
 | Explorer | **[https://explorer.optimism.io](https://explorer.optimism.io)** |
 | HTTP Endpoint | Optimism also provides this endpoint: **`https://mainnet.optimism.io`.** _But it is not for production systems and is rate limited._   |
 | Sequencer URL<sup>1</sup> | **`https://mainnet-sequencer.optimism.io/`** |
-| L1 Contract Addresses | [link](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts/deployments/mainnet#layer-1-contracts) |
-| L2 Contract Addresses | [link](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts/deployments/mainnet#layer-2-contracts) |
+| L1 Contract Addresses | [link](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock/deployments/optimism-mainnet) |
+| L2 Contract Addresses | [link](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock/deployments/optimism-mainnet) |
 | chainid.link | [https://chainid.link/?network=optimism](https://chainid.link/?network=optimism)
 
 (1) The sequencer URL is write only, it only accepts `eth_sendRawTransaction` requests.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Fix the URL for deployment contracts in the:
- https://community.optimism.io/docs/developers/bridge/messaging/#communication-basics-between-layers
- https://community.optimism.io/docs/useful-tools/networks/#op-mainnet

**Tests**

Docs update

**Additional context**

**Metadata**
