### PR TITLE
Update README.md with the new "cannon" links from the Monorepo

### DIFF
--- a/src/docs/protocol/README.md
+++ b/src/docs/protocol/README.md
@@ -28,4 +28,4 @@ The first step to decentralizing the sequencer is to still have one sequencer at
 After this, the next step is to support multiple concurrent sequencers. This can be simply achieved by adopting a standard BFT consensus protocol, as used by other L1 protocols and sidechains like Polygon and Cosmos.
 
 
-You can keep up with the roadmap progress in [Cannon repository](https://github.com/ethereum-optimism/cannon/) for the fault proofs and [Optimism specs repository](https://github.com/ethereum-optimism/optimism/tree/65ec61dde94ffa93342728d324fecf474d228e1f/specs) for the overall protocol work.
+You can keep up with the roadmap progress in [Cannon repository](https://github.com/ethereum-optimism/optimism/tree/develop/cannon) for the fault proofs and [Optimism specs repository](https://github.com/ethereum-optimism/optimism/tree/65ec61dde94ffa93342728d324fecf474d228e1f/specs) for the overall protocol work.


### PR DESCRIPTION
I found it more useful for users/doc reviewers to land into (https://github.com/ethereum-optimism/optimism/tree/develop/cannon) and get direct information about the onchain MIPS instruction emulator than to drive them towards a repo that is now archived "(https://github.com/ethereum-optimism/cannon/)" and won't contain the latest docs and development information in the future.

Please review and approve this PR if this also makes sense to other code owners for this project.