### PR TITLE
Fix: fix several typos in the document

### DIFF
--- a/src/docs/developers/bedrock/differences.md
+++ b/src/docs/developers/bedrock/differences.md
@@ -218,7 +218,7 @@ Visualized, this flow looks like this:
 By posting the proof upfront, it gives onchain monitoring tools enough time to detect a fraudulent withdrawal proof and attempt corrective action. 
 Regular users can do this monitoring too. For example, an exchange could halt withdrawals in the event of a fraudulent proof.
 
-Since this change fundamentally changes the way withdrawals are handled, it is **not** backwards-compatible with the old network. If you are performing withdrawals outside our standard bridge interface, you will need to update your software. The easiest way to to do this is to use our [TypeScript SDK](https://github.com/ethereum-optimism/optimism/tree/65ec61dde94ffa93342728d324fecf474d228e1f/packages/sdk), which includes two-phase withdrawals support out of the box.
+Since this change fundamentally changes the way withdrawals are handled, it is **not** backwards-compatible with the old network. If you are performing withdrawals outside our standard bridge interface, you will need to update your software. The easiest way to do this is to use our [TypeScript SDK](https://github.com/ethereum-optimism/optimism/tree/65ec61dde94ffa93342728d324fecf474d228e1f/packages/sdk), which includes two-phase withdrawals support out of the box.
 
 For more information on two-phase withdrawals, see the withdrawals specification on [GitHub](https://github.com/ethereum-optimism/optimism/blob/65ec61dde94ffa93342728d324fecf474d228e1f/specs/withdrawals.md).
 
@@ -344,7 +344,7 @@ To create a deposit we recommend that you use the pre-Bedrock contracts [`L1Stan
 
 With the OptimismPortal’s `depositTransaction` function you can do from L1 anything you can do by contacting L2 directly: send transactions, send payments, create contracts, etc.
 This provides an uncensorable alternative in case the sequencer is down. 
-Even though the sequencer is down, verifiers (nodes that synchronize the Optimism state from L1) are still going to receive such transactions and modify the state accordingly. 
+Even though the sequencer is down, verifiers (nodes that synchronize the Optimism state from L1) are still going to receive such transactions and to modify the state accordingly. 
 When the sequencer is back up it has to process the transactions in the same order to have a valid state.
 
 

--- a/src/docs/developers/bedrock/node-operator-guide.md
+++ b/src/docs/developers/bedrock/node-operator-guide.md
@@ -27,7 +27,7 @@ The architecture of a typical Bedrock deployment looks like this:
 
 We recommend the following minimum system requirements to run Bedrock:
 
-- `op-node`: Minimum 2CPUs, 4GB RAM. No storage is necessary.
+- `op-node`: Minimum 2 CPUs, 4GB RAM. No storage is necessary.
 - `op-geth`: Minimum 4 CPUs, 8GB RAM. At least 40GB of storage is required for OP Goerli or OP Sepolia. At least 600GB of storage is required for mainnet. Storage must be SSD. Requirements are significantly higher for archive nodes.
 
 ## Getting the Software
@@ -54,7 +54,7 @@ To configure your node, you will need to do the following:
 ### Configuring op-geth
 
 :::tip
-Even though the Docker image for the Execution Engine is called `op-geth`, the actually binary is still called `geth` in order to minimize differences between `op-geth` and `go-ethereum`.
+Even though the Docker image for the Execution Engine is called `op-geth`, the actual binary is still called `geth` in order to minimize differences between `op-geth` and `go-ethereum`.
 :::
 
 We'll start with `op-geth`'s configuration because it is more complex. As mentioned before, `op-geth` is a minimal fork of `go-ethereum`. As a result, it stores its state in a database that requires initialization. Initialization is done one of two ways, depending on which network you're deploying:


### PR DESCRIPTION
**Description**

Several typos in the following documents are fixed:

differences.md
node-operator-guide.md