### PR TITLE
Update docs

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -123,7 +123,7 @@ module.exports = {
             iconPrefix: "fab fa-",
             iconClass: "color-twitter",
             text: "Twitter",
-            link: "https://twitter.com/optimismFND",
+            link: "https://twitter.com/Optimism",
           },
           {
             icon: "twitch",

--- a/src/docs/governance/README.md
+++ b/src/docs/governance/README.md
@@ -47,7 +47,7 @@ You can learn more in the [Token House Onboarding Hub](https://plaid-cement-e44.
     
 ## Citizens' House
 
-The Citizens' House is a large-scale experiment in [non-plutocratic governance](https://vitalik.ca/general/2021/08/16/voting3.html) and retroactive funding of public goods. 
+The Citizens' House is a large-scale experiment in [non-plutocratic governance](https://vitalik.eth.limo/general/2021/08/16/voting3.html) and retroactive funding of public goods. 
 
 The Citizens' House is responsible for [retroactive public goods funding (RPGF)](https://medium.com/ethereum-optimism/retroactive-public-goods-funding-33c9b7d00f0c). 
 For more information about the Citizens' House, read [the Overview](./citizens-house.md).

--- a/src/docs/governance/airdrop-1.md
+++ b/src/docs/governance/airdrop-1.md
@@ -162,6 +162,6 @@ As always: stay safe and stay Optimistic.
 - **Airdrop #1 Dashboard:** [https://dune.com/optimismfnd/optimism-airdrop-1](https://dune.com/optimismfnd/optimism-airdrop-1)
 - **Detailed Protocol Metrics:** [https://dune.com/optimismfnd/Optimism](https://dune.com/optimismfnd/Optimism)
 - **OP Token Address:** [0x4200000000000000000000000000000000000042](https://explorer.optimism.io/address/0x4200000000000000000000000000000000000042)
-- **Optimism on Twitter:** [https://twitter.com/optimismFND](https://twitter.com/optimismFND)
+- **Optimism on Twitter:** [https://twitter.com/Optimism](https://twitter.com/Optimism)
 - **Join the Optimism Discord:** [https://discord-gateway.optimism.io/](https://discord-gateway.optimism.io/)
 - **CSV with the list of airdropped addresses:** [op_airdrop1_addresses_detailed_list.csv](https://github.com/ethereum-optimism/op-analytics/blob/main/reference_data/address_lists/op_airdrop1_addresses_detailed_list.csv)

--- a/src/docs/governance/allocations.md
+++ b/src/docs/governance/allocations.md
@@ -48,9 +48,16 @@ Airdrop 3 took place on Monday, September 18. The airdrop allocated **19,411,313
 
 See the [Airdrop #3 documentation](airdrop-3.md) for a detailed breakdown of eligibility criteria. 
 
-### Future airdrops (#4, 5, …)
+### Airdrop #4
 
-An allocation of **14%** of the OP token supply will be held in reserve for future user airdrops. 
+Airdrop 4 distributes **10,343,757.81 OP to 22,998 unique addresses** as a ‘thank you’ to the artists, creators, and pioneers who have played a role in creating culture across the Superchain and across the crypto ecosystem as a whole.
+Creators with addresses that deployed NFT contracts on Ethereum L1, Base, OP Mainnet and Zora before 2024-01-10 00:00:00 UTC were considered in this airdrop.
+
+See the [Airdrop #4 documentation](airdrop-4.md) for a detailed breakdown of eligibility criteria. 
+
+### Future airdrops (#5, #6, …)
+
+Roughly **560M OP** remains for future user airdrops.
 As a result of the game-able nature of airdrops, the Optimism Foundation will be responsible for determining airdrop metrics as fairly as possible. 
 The intent behind airdrops is to distribute them to addresses which positively impact the Optimism community. Participation on governance forums will not be used as a criteria for future airdrops. The best way to improve your odds of receiving future airdrops is to get meaningfully involved!
 

--- a/src/docs/governance/citizens-house.md
+++ b/src/docs/governance/citizens-house.md
@@ -3,7 +3,7 @@ title: Overview
 lang: en-US
 ---
 
-The Citizens' House is a large-scale experiment in [non-plutocratic governance](https://vitalik.ca/general/2021/08/16/voting3.html) and retroactive funding of public goods. 
+The Citizens' House is a large-scale experiment in [non-plutocratic governance](https://vitalik.eth.limo/general/2021/08/16/voting3.html) and retroactive funding of public goods. 
 The Citizens’ House will work alongside the Token House to govern the Optimism Collective. 
 
 **In its first stage, the Citizens’ House is solely responsible for voting on the allocation of Retroactive Public Goods Funding (RetroPGF)**. 

--- a/src/docs/governance/economics.md
+++ b/src/docs/governance/economics.md
@@ -49,7 +49,7 @@ In the long-term, the Foundation expects this mechanism to drive a wide range of
 ## Value from public goods drives demand for blockspace
 
 Funding public goods drives growth — and therefore network revenues — from the ground up. 
-In our [first round](https://vitalik.ca/general/2021/11/16/retro1.html) of RetroPGF, Optimism funded a set of hugely valuable developer tools and core infrastructure. 
+In our [first round](https://vitalik.eth.limo/general/2021/11/16/retro1.html) of RetroPGF, Optimism funded a set of hugely valuable developer tools and core infrastructure. 
 The aggregate effect is an ecosystem that is easier to build on, learn about, and connect to, in turn driving application usage and generating more demand for blockspace.
 
 But what value do these public goods provide, and for whom is it valuable? 

--- a/src/docs/governance/retropgf-1.md
+++ b/src/docs/governance/retropgf-1.md
@@ -12,7 +12,7 @@ In the first round of RetroPGF, 76 projects were nominated, and 58 were awarded 
 The median funding received by a project in RetroPGF 1 was $14,670, while the top 10% of projects received more than $36,919.
 
 - You can find a sheet with all projects and their funding allocations [**here**](https://docs.google.com/spreadsheets/d/1g4ilAByMNQsmlBC8cskQip7Ojd_qK6IhozJCyoVfU9k).
-- You can find Vitalik's review of the round [**here**](https://vitalik.ca/general/2021/11/16/retro1.html)
+- You can find Vitalik's review of the round [**here**](https://vitalik.eth.limo/general/2021/11/16/retro1.html)
 
 ## Process and timeline overview
 1. Badgeholder selection - In RetroPGF Round 1, 24 badgeholders, made up of 8 Optimists and 16 Ethereum community members, were selected to vote on distributing retrofunding to nominated projects.

--- a/src/docs/governance/retropgf-2.md
+++ b/src/docs/governance/retropgf-2.md
@@ -19,7 +19,7 @@ In this second round of RetroPGF, 195 people and projects were nominated, and al
 
 ## Process and timeline overview
 1. Badgeholder selection - badgeholders have the power to distribute OP tokens to projects. They’re instrumental in running an effective RetroPGF round. For RetroPGF Round 2, badgeholders were selected across four different criteria.
-   1. 14 badgeholders were selected based on their participation as badgeholders in [round one of RetroPGF](https://vitalik.ca/general/2021/11/16/retro1.html)
+   1. 14 badgeholders were selected based on their participation as badgeholders in [round one of RetroPGF](https://vitalik.eth.limo/general/2021/11/16/retro1.html)
    2. 21 badgeholders were selected by the Optimism Foundation
    3. 10 badgeholders were [elected by Optimism’s Token House](https://snapshot.org/#/opcollective.eth/proposal/0x22d4c3ab56832de58c1774d1a0aeb61ba6dde8b16c0f8382f85d8935f3ee1f11)
    4. 29 badge holders were nominated by badgeholders from the three categories above


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

This PR brings with it the following changes:
- Vitalik's blog is being linked correctly (vitalik.ca -> vitalik.eth.limo)
- Optimism's Twitter is being linked correctly (optimismFND -> Optimism, except for in tweets since Twitter resolves them by ID)
- Added information about Airdrop 4 in allocations.md
- Changed old information about future airdrops
