### PR TITLE
Add 'Ethereum Ecosystem' Link to Community Dropdown

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -146,6 +146,12 @@ module.exports = {
             link: "https://www.optimism.io/apps/all",
           },
           {
+            icon: "external-link-square",
+            iconClass: "color-ethereum-ecosystem",
+            text: "Ethereum Ecosystem",
+            link: "https://www.ethereum-ecosystem.com/blockchains/optimism",
+          },
+          {
             icon: "globe",
             iconClass: "color-optimism",
             text: "optimism.io",

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -313,3 +313,7 @@ div.theme-container:not(.has-sidebar) {
 .color-ecosystem {
   color: #ea94db;
 }
+
+.color-ethereum-ecosystem {
+  color: #1c1cff;
+}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

I've submitted a PR to include a link to '[Ethereum Ecosystem](https://www.ethereum-ecosystem.com/blockchains/optimism)' under the Optimism Docs 'Community' tab. This unofficial ecosystem page lists over 250 dApps available on Optimism, fostering a richer community experience. 


![Capture d’écran 2024-03-05 à 14 04 44](https://github.com/ethereum-optimism/community-hub/assets/43566493/46f4ee73-a641-4cb4-aa9c-922cf8032aa6)

**Additional context**

Supported by grants from the Optimism collective during grant season 4 and RetroPGF3, [Ethereum Ecosystem](https://www.ethereum-ecosystem.com/)'s goal is to boost visibility for users to discover the expansive Optimism ecosystem easily.

