### PR TITLE
chore: fix typos

### DIFF
--- a/src/docs/developers/nodes/testnet.md
+++ b/src/docs/developers/nodes/testnet.md
@@ -6,7 +6,7 @@ lang: en-US
 #### [Please follow these steps first if you have not done so already.](./intro.md)
 
 ::: info Migrated vs Non-Migrated Networks
-Migrated Networks, *OP Mainnet* and *OP Goerli*, were running before the Bedrock upgrade. Non-Migrated Networks, *OP Sepolia*, have only existed in a post Bedrock world. The way transaction execution is handled is funadmentally different pre- vs post-bedrock. Migrated networks are required to initialize their nodes with a data directory and non-migrated networks can simply initialize from a genesis file.
+Migrated Networks, *OP Mainnet* and *OP Goerli*, were running before the Bedrock upgrade. Non-Migrated Networks, *OP Sepolia*, have only existed in a post Bedrock world. The way transaction execution is handled is fundamentally different pre- vs post-bedrock. Migrated networks are required to initialize their nodes with a data directory and non-migrated networks can simply initialize from a genesis file.
 :::
 
 ## OP Sepolia initialization


### PR DESCRIPTION
fix a typo: `funadmentally`->`fundamentally`