### PR TITLE
cleaning up home and header links

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -70,36 +70,22 @@ module.exports = {
       /* When you update here, don't forget to update the tiles
          in src/README.md */
       {
-        text: "Quick Start",
-        link: "/docs/guides/",
-      },
-      {
-        text: "How Optimism Works",
-        link: "/docs/protocol/",
-      },
-      {
-        text: "Support",
-        link: "/docs/biz/",
-      },
-      {
-        text: "Security",
-        link: "/docs/security-model/",
-      },
-      {
-        text: "Dev Docs",
-        link: "/docs/developers/",
-      },
-      {
-        text: "Identity",
-        link: "/docs/identity/",
-      },
-      {
         text: "Governance",
         link: "/docs/governance/",
       },
       {
         text: "Contribute",
         link: "/docs/contribute/",
+      },
+      {
+        text: "Support",
+        link: "/docs/biz/",
+      },
+      {
+        text: "Technical Docs",
+        link: "https://docs.optimism.io/",
+        target: '_blank', 
+        rel: 'noopener noreferrer' 
       },
       {
         text: "Community",

--- a/src/.vuepress/theme/components/Anchor.js
+++ b/src/.vuepress/theme/components/Anchor.js
@@ -69,7 +69,7 @@ export default Vue.extend({
                                     " Connect with Optimism"
                                 ])
                             ]),
-                            h("a", { attrs: { href: "https://github.com/ethereum-optimism/optimism/issues", target: "_blank" } }, [
+                            h("a", { attrs: { href: "https://github.com/ethereum-optimism/community-hub/issues", target: "_blank" } }, [
                                 h("div", [
                                     h("i", { attrs: { class: "fab fa-github" } }),
                                     " Make an issue on GitHub"

--- a/src/README.md
+++ b/src/README.md
@@ -16,7 +16,7 @@ features:
     details: Check out the Optimism community and join the conversation.
     link: /docs/contribute/
 
-  - title: Developer docs
+  - title: Developer Documentation
     icon: code
     details: Technical documentation website and information about the OP Stack.
     link: https://docs.optimism.io/

--- a/src/README.md
+++ b/src/README.md
@@ -6,43 +6,18 @@ heroImage: /assets/logos/header.png
 heroText: " "
 
 features:
-  - title: Quick Start
+  - title: Governance
     icon: book
-    details: How-to guides and tutorials for users and developers.
-    link: /docs/guides/
-    
-  - title: How OP Mainnet works
-    icon: info-square
-    details: General explanation of what makes OP Mainnet tick.
-    link: /docs/protocol/2-rollup-protocol/
-
-  - title: OP Mainnet's Security Model
-    icon: shield
-    details: Understand the safety and liveness properties of OP Mainnet.
-    link: /docs/security-model/
-
-  - title: Protocol specs
-    icon: ruler-triangle
-    details: More detailed information about how OP Mainnet works under the hood.
-    link: /docs/protocol/
-
-  - title: Developer docs
-    icon: code
-    details: Resources for building a decentralized application on OP Mainnet.
-    link: /docs/developers/
-
-  - title: Tools for developers
-    icon: hammer
-    details: Useful third-party tools for easier development and deployment.
-    link: /docs/useful-tools/
-  
-  - title: Superchain Explainer
-    icon: link
-    details: Technical explainer for the OP Stack and Superchain.
-    link: https://stack.optimism.io/docs/understand/explainer/
+    details: Learn about the experimental and agile approach to governing the Optimism Collective.
+    link: /docs/governance/
 
   - title: Contribute
     icon: hands-helping
     details: Check out the Optimism community and join the conversation.
     link: /docs/contribute/
+
+  - title: Developer docs
+    icon: code
+    details: Technical documentation website and information about the OP Stack.
+    link: https://docs.optimism.io/
 ---


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A lot of the links on the landing page and the header of the website just redirect to the technical docs. I removed those links and collapsed them into a single "Technical Documentation" link

