### PR TITLE
Typo Update citizen-house-overview.mdx

### DIFF
--- a/pages/citizens-house/citizen-house-overview.mdx
+++ b/pages/citizens-house/citizen-house-overview.mdx
@@ -16,7 +16,7 @@ The goals of the Citizens' House are to:
 ## Responsibilities
 In its current phase, the Citizens' House is responsible for voting on the allocation of Retroactive Public Goods Funding (Retro Funding), and has the power to veto protocol upgrade proposals made by the Token House. 
 
-The Citizens' House is in an initial bootstrapping phase, and will take on progressively more governance responsibilities over tme, such as determining scope and round sizing. Holding a voting badge in this initial stage does not guarantee permanent participation in the Citizens’ House and future iterations of Retro Funding.
+The Citizens' House is in an initial bootstrapping phase, and will take on progressively more governance responsibilities over time, such as determining scope and round sizing. Holding a voting badge in this initial stage does not guarantee permanent participation in the Citizens’ House and future iterations of Retro Funding.
 
 ## Moving Forward
 


### PR DESCRIPTION
**Description**

<img width="1217" alt="Снимок экрана 2024-11-11 в 19 39 34" src="https://github.com/user-attachments/assets/efcc6061-fff0-4a6e-a4de-45e26998584c">

"tme" corrected to "**time**" in the sentence.