### PR TITLE
Typo Update get-support.mdx

### DIFF
--- a/pages/grant/get-support.mdx
+++ b/pages/grant/get-support.mdx
@@ -16,7 +16,7 @@ You will be welcomed by [insightful metrics](https://dune.com/optimismfnd/Optimi
 Steps to take if you would like developer support immediately, ranked in order of response times. 
 
 1. Get help quickly in our [Developer Support repo](https://github.com/ethereum-optimism/developers/discussions).
-1. See our [Developer Documentation](https://docs.optimism.io/) & [Tutorials](https://github.com/ethereum-optimism/optimism-tutorial).
+2. See our [Developer Documentation](https://docs.optimism.io/) & [Tutorials](https://github.com/ethereum-optimism/optimism-tutorial).
 
 ## Marketing Requests 🦸🦸
 


### PR DESCRIPTION
I found an issue with the list numbering in the **Developer Support** section. There were two items marked as "1.", which caused inconsistency in the ordered list format. For proper formatting and consistency, each item should have its own unique number (or the list can be changed to a bulleted list if the order is not important).

### Issue:
```
1. Get help quickly in our [Developer Support repo](https://github.com/ethereum-optimism/developers/discussions).
1. See our [Developer Documentation](https://docs.optimism.io/) & [Tutorials](https://github.com/ethereum-optimism/optimism-tutorial).
```

### Solution:
I updated the numbering to:
```
1. Get help quickly in our [Developer Support repo](https://github.com/ethereum-optimism/developers/discussions).
2. See our [Developer Documentation](https://docs.optimism.io/) & [Tutorials](https://github.com/ethereum-optimism/optimism-tutorial).
```

This change ensures proper list formatting and prevents confusion when reading the documentation.
