### PR TITLE
Typo fix Update how-to-delegate.mdx

### DIFF
--- a/pages/token-house/how-to-delegate.mdx
+++ b/pages/token-house/how-to-delegate.mdx
@@ -20,7 +20,7 @@ Before becoming a delegate, review the [Prospective Delegate Gov Onboarding Hub]
 
 2. [Go to the same voting app](https://vote.optimism.io/) to delegate your tokens to your own address.
 
-      - Pease note that snapshots of delegate voting power are taken when a proposal is created
+      - Please note that snapshots of delegate voting power are taken when a proposal is created
 
 3. Once you’ve been added as a delegate in the next voting cycle, you can start [voting](https://vote.optimism.io/)!
     - Go to the [Optimism voting app](https://vote.optimism.io/), connect your wallet, and vote! There is no minimum OP to begin voting requirement, but you will need to have the OP tokens you wish to delegate or vote with in your wallet when the voting measurement is taken. Tokens that are staked or LP’d at the time of measurement do not carry voting power.


### PR DESCRIPTION
### Description:
This PR fixes a minor but important typo in the delegation instructions documentation.

#### Context:
The sentence currently reads:  
*"Pease note that snapshots of delegate voting power are taken when a proposal is created."*  

The word "Pease" is a typo and should be corrected to "Please." The corrected sentence is:  
*"Please note that snapshots of delegate voting power are taken when a proposal is created."*

#### Why this matters:
While this typo is small, it impacts the professionalism and clarity of the documentation. Correcting such errors helps maintain the credibility of the project and ensures that readers can fully trust the material provided. Clear and error-free instructions are essential for user confidence, especially in governance processes where accuracy is critical.

#### Changes made:
- Replaced "Pease" with "Please" in the relevant sentence. 

No other changes were made to the document.

Thank you for reviewing this minor fix!