### PR TITLE
Typo fix Update op-token-overview.mdx

### DIFF
--- a/pages/op-token/op-token-overview.mdx
+++ b/pages/op-token/op-token-overview.mdx
@@ -22,7 +22,7 @@ Let’s break it down ⤵️
 
 Rewards for the OP economy comes from ownership of OP Mainnet and the value of its blockspace.
 
-Today, rewards comes directly from the centralized sequencer, accruing to The Optimism Foundation for redistribution. In the future, rewards can accrue directly to the protocol by selling the right to participate in Optimism’s decentralized sequencing network.
+Today, rewards come directly from the centralized sequencer, accruing to The Optimism Foundation for redistribution. In the future, rewards can accrue directly to the protocol by selling the right to participate in Optimism’s decentralized sequencing network.
 
 Simply put: the right to blockspace is the sustainable source of revenue that drives OP’s economic model and grows with the network itself.
 


### PR DESCRIPTION
**Description:**  

This pull request fixes a grammatical error in the "Demand for OP blockspace generates revenue" section of the documentation.  

### Summary of the Fix:  
The original text:  
> "Today, rewards comes directly from the centralized sequencer..."  

has been corrected to:  
> "Today, rewards **come** directly from the centralized sequencer..."  

### Why This Fix is Important:  
The subject "rewards" is plural, and the verb "comes" is incorrect in this context. The proper conjugation, "come," ensures grammatical accuracy and improves the professionalism and clarity of the documentation. Clear and correct language is essential for conveying trust and reliability in technical and governance-related documentation.  

Thank you for considering this correction! Let me know if there are additional updates needed.