### PR TITLE
Typo Update law-of-chains-disclaimer.mdx

### DIFF
--- a/pages/welcome/governing-docs/law-of-chains-disclaimer.mdx
+++ b/pages/welcome/governing-docs/law-of-chains-disclaimer.mdx
@@ -17,6 +17,6 @@ If Participant Protections are violated, one may appeal to Optimism Governance. 
 
 Relatedly, participants that subscribe to the Law of Chains do so independently, and they conduct themselves independently under it, bearing their own risks and rewards. No party acquires the ability to contractually bind the other by virtue of their shared commitment to these guidelines. The Law of Chains does not create a partnership, joint venture, employment, franchise, or agency relationship among anyone. 
 
-The Law of Chains is a set of guidelines.  It is not a contract.  If you need legally enforceable guarantees from specific people or entities, you need some kind of specific contract with them. This document, standing alone, is not that.  For more information, see Law Chains, Section 8 (Enforcement). 
+The Law of Chains is a set of guidelines.  It is not a contract.  If you need legally enforceable guarantees from specific people or entities, you need some kind of specific contract with them. This document, standing alone, is not that.  For more information, see Law of Chains, Section 8 (Enforcement). 
 
 Last Updated:  July 25, 2023


### PR DESCRIPTION
###  Description:
This PR addresses a minor but important typo in the "Law of Chains Disclaimer" document. The reference in the final paragraph was incorrectly written as:

> "see Law Chains, Section 8 (Enforcement)"

This has been corrected to:

> **"see Law of Chains, Section 8 (Enforcement)"**

#### Importance of the Fix:
1. **Consistency with Document Title**: The correct title of the referenced document is "Law of Chains." Ensuring this accuracy maintains the credibility and professionalism of the text.
2. **Clarity for Readers**: An incorrect title could lead to confusion for readers or participants trying to locate or understand the referenced material.
3. **Improved Usability**: By aligning the reference with the actual document title, we enhance the usability of the disclaimer for all ecosystem participants.

This is a straightforward, non-breaking change that improves the quality and clarity of the content. Please review and merge at your earliest convenience.