### PR TITLE
Add Counts fro Drop 4

### DIFF
--- a/pages/op-token/airdrops/airdrop-4.mdx
+++ b/pages/op-token/airdrops/airdrop-4.mdx
@@ -6,7 +6,7 @@ description: Airdrop 4 [CLAIMABLE] Available for claim by qualified addresses. ~
 
 # Airdrop 4
 
-Airdrop #4 celebrates the vibrant creative energy that artists introduce to the Superchain, and highlights the essential role creators fulfill within the Optimism Collective and the broader Ethereum ecosystem. Creators with addresses that deployed NFT contracts on Ethereum L1, Base, OP Mainnet and Zora before 2024-01-10 00:00:00 UTC were considered in this airdrop.
+Airdrop #4 celebrates the vibrant creative energy that artists introduce to the Superchain, and highlights the essential role creators fulfill within the Optimism Collective and the broader Ethereum ecosystem. Creators with addresses that deployed NFT contracts on Ethereum L1, Base, OP Mainnet and Zora before 2024-01-10 00:00:00 UTC were considered in this airdrop. The airdrop allocated 10,343,757.81 OP to 22,998 unique addresses.
 
 Read on for more detail about eligibility criteria and allocations.
 

--- a/pages/op-token/airdrops/airdrop-4.mdx
+++ b/pages/op-token/airdrops/airdrop-4.mdx
@@ -6,7 +6,7 @@ description: Airdrop 4 [CLAIMABLE] Available for claim by qualified addresses. ~
 
 # Airdrop 4
 
-Airdrop #4 celebrates the vibrant creative energy that artists introduce to the Superchain, and highlights the essential role creators fulfill within the Optimism Collective and the broader Ethereum ecosystem. Creators with addresses that deployed NFT contracts on Ethereum L1, Base, OP Mainnet and Zora before 2024-01-10 00:00:00 UTC were considered in this airdrop. The airdrop allocated 10,343,757.81 OP to 22,998 unique addresses.
+Airdrop #4 celebrates the vibrant creative energy that artists introduce to the Superchain, and highlights the essential role creators fulfill within the Optimism Collective and the broader Ethereum ecosystem. Creators with addresses that deployed NFT contracts on Ethereum L1, Base, OP Mainnet and Zora before 2024-01-10 00:00:00 UTC were considered in this airdrop.
 
 Read on for more detail about eligibility criteria and allocations.
 


### PR DESCRIPTION
Adds Addresses and amounts for Drop 4 description for better trackability.

Validated against the [address list](https://github.com/ethereum-optimism/op-analytics/blob/main/reference_data/address_lists/op_airdrop_4_simple_list.csv) and [claim flow](https://app.optimism.io/airdrops/4).