### PR TITLE
docs: Improve Clarity and Grammar Update experimentation-with-citizen…

### DIFF
--- a/pages/citizens-house/experimentation-with-citizenship.mdx
+++ b/pages/citizens-house/experimentation-with-citizenship.mdx
@@ -17,7 +17,7 @@ Any changes to the Citizens' House, including changes to Citizen selection, shou
 
 ## Taking an experimental approach to Citizen selection
 
-An experimental approach to Citizen selection ensures that changes are made based on evidence rather than gut feeling. Guesswork and informed opinions play a part in the formation of hypotheses, but diverging opinions are settled through hypothesis-testing. This process ensures that as Citizen selection evolves over time, it is always evolving in the direction of progress towards the objectives. Changes that have an undesirable effect are rolled back, and mistakes are learned from to inform future improvements.
+An experimental approach to Citizen selection ensures that changes are made based on evidence rather than gut feeling. Guesswork and informed opinions play a part in the formation of hypotheses, but diverging opinions are settled through hypothesis-testing. This process ensures that as Citizen selection evolves over time, it is always evolving in the direction of progress towards the objectives. Changes that have an undesirable effect are rolled back, and mistakes are used as learning opportunities to inform future improvements.
 
 Disclaimer: *The types of experiments run in the name of Citizen selection are unlikely to be double-blind controlled trials. We seek to use the principles and practices of experimentation to the maximum extent feasible, with the aim of growing the amount of high-confidence knowledge about Citizen selection that the Collective has access to.*
 


### PR DESCRIPTION
**Description**
 
This update refines a sentence in the "Experimentation with Citizenship" document to improve its clarity and grammatical accuracy. The original phrasing, *"mistakes are learned from,"* was identified as awkward and inconsistent with standard English usage.  

The revised version:  
> "Changes that have an undesirable effect are rolled back, and mistakes are used as learning opportunities to inform future improvements."  

This change ensures the text reads naturally and aligns with the professional tone of the document while preserving its original intent.
