### PR TITLE
docs: typo fix Update important-terms.mdx

### DIFF
--- a/pages/contribute/important-terms.mdx
+++ b/pages/contribute/important-terms.mdx
@@ -18,7 +18,7 @@ An inclusive, open source Superchain that sustainably funds Public Goods, dispel
 
 ### The RetroPGF Flywheel
 
-![Retro Founding flywheel](/img/citizen-house/how-retro-funding-works.png)
+![Retro Funding flywheel](/img/citizen-house/how-retro-funding-works.png)
 
 Optimism generates revenue through transaction fees paid on OP Mainnet and other OP Chains. Part of this revenue is directed by the Optimism Collective through RetroPGF. Better public goods means more development, which creates more revenue that can be directed to public goods. Read [more about the flywheel](https://app.optimism.io/retropgf).
 


### PR DESCRIPTION
**Description**

The phrase "Retro Founding flywheel" contains a typo. It should be "Retro **Funding** flywheel" to correctly align with the topic of RetroPGF (Retroactive Public Goods Funding).