### PR TITLE
docs: fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Then, run `pnpm dev` to start the development server and visit localhost:3000.
 
 ## Contributions
 
-Please see the [CONTRIBUTING.md](https://github.com/ethereum-optimism/docs/blob/main/CONTRIBUTING.md) page for specifics on how to write PRs, use the linter, run spellcheck, add dictionary terms, etc. You should also review the [Optimism Documentation Style Guide](/pages/connect/contribute/style-guide.mdx) for additional guidelines, especially if you are writing entirely brand new pages to the developer docs, as opposed to smaller edits and/or revisions.
+Please see the [CONTRIBUTING.md](https://github.com/ethereum-optimism/docs/blob/main/CONTRIBUTING.md) page for specifics on how to write PRs, use the linter, run spellcheck, add dictionary terms, etc. You should also review the [Optimism Documentation Style Guide](https://github.com/ethereum-optimism/docs/blob/main/pages/connect/contribute/style-guide.mdx) for additional guidelines, especially if you are writing entirely brand new pages to the developer docs, as opposed to smaller edits and/or revisions.
 
 ## Project Board
 


### PR DESCRIPTION

**Description**

Fixes "Optimism Documentation Style Guide" hyperlink.

**Tests**

Broken Link: https://github.com/ethereum-optimism/community-hub/blob/main/pages/connect/contribute/style-guide.mdx
- broken, leads to 404 - page not found page

Correct Link: https://github.com/ethereum-optimism/docs/blob/main/pages/connect/contribute/style-guide.mdx
- valid, lead to Optimism Documentation Style Guide

**Additional context**

n/a

**Metadata**

n/a