### PR TITLE
docs: Fix Subject-Verb Agreement in OP Tokenomics Text

### DIFF
--- a/pages/op-token/op-token-overview.mdx
+++ b/pages/op-token/op-token-overview.mdx
@@ -20,9 +20,9 @@ Let’s break it down ⤵️
 
 ## Demand for OP blockspace generates revenue
 
-Rewards for the OP economy comes from ownership of OP Mainnet and the value of its blockspace.
+Rewards for the OP economy come from ownership of OP Mainnet and the value of its blockspace.
 
-Today, rewards comes directly from the centralized sequencer, accruing to The Optimism Foundation for redistribution. In the future, rewards can accrue directly to the protocol by selling the right to participate in Optimism’s decentralized sequencing network.
+Today, rewards come directly from the centralized sequencer, accruing to The Optimism Foundation for redistribution. In the future, rewards can accrue directly to the protocol by selling the right to participate in Optimism’s decentralized sequencing network.
 
 Simply put: the right to blockspace is the sustainable source of revenue that drives OP’s economic model and grows with the network itself.
 


### PR DESCRIPTION
**Description**

I noticed a couple of errors in the text that needed a quick fix. Specifically, the sentences "Rewards for the OP economy comes" and "Today, rewards comes directly" were using incorrect subject-verb agreement. 

I’ve updated them to:  
- "Rewards for the OP economy **come**"  
- "Today, rewards **come** directly"  

This ensures the text reads more smoothly and maintains consistency in grammar.