### PR TITLE
docs: typo fix Update how-retro-funding-works.mdx

### DIFF
--- a/pages/citizens-house/how-retro-funding-works.mdx
+++ b/pages/citizens-house/how-retro-funding-works.mdx
@@ -6,7 +6,7 @@ description: Retroactive Public Goods Funding (Retro Funding) is based on the id
 
 # How Retro Funding Works
 
-Retroactive Public Goods Funding (Retro Funding) is based on the idea that it’s easier to agree on what was useful in the past than what might be useful in the future. This is a series of experiments where members of the Citizens’ House allocate surplus protocol revenue or portions of the Retro Funding token allocation to projects they deem have provided positive impact to the Optimism Collective and across the Superchain. This is core to Optimism’s value of impact=profit: the idea that positive impact to the collective should be rewarded proportionally with profit to the individual.
+Retroactive Public Goods Funding (Retro Funding) is based on the idea that it’s easier to agree on what was useful in the past than what might be useful in the future. This is a series of experiments where members of the Citizens’ House allocate surplus protocol revenue or portions of the Retro Funding token allocation to projects they deem have provided positive impact to the Optimism Collective and across the Superchain. This is core to Optimism’s value of impact=profit: the idea that positive impact on the collective should be rewarded proportionally with profit to the individual.
 
 These rewards create strong incentives for people to build public goods that benefit the Optimism Collective. The aggregate effect is an ecosystem that is easier to build on, learn about, and connect to, in turn driving application usage and generating more demand for blockspace. By funding public goods sustainably, the Collective can create a rich ecosystem and a better economy.
 


### PR DESCRIPTION
**Description**

**Error:**
"impact=profit: the idea that positive impact to the collective should be rewarded proportionally with profit to the individual."

**Correction:**
"impact=profit: the idea that positive impact **on** the collective should be rewarded proportionally with profit to the individual."

**Explanation:**
The correct phrase is "positive impact on the collective" rather than "impact to the collective." The preposition "on" is used to indicate the subject affected by the impact.

**Happy New Year!**