### PR TITLE
contribute-overview.mdx

### DIFF
--- a/pages/contribute/contribute-overview.mdx
+++ b/pages/contribute/contribute-overview.mdx
@@ -30,7 +30,7 @@ Most importantly, make sure that your contributions align with the [Collective I
 
 You can contribute towards the collective in a million different ways, and there is no way we could make processes for all of these contributions. Nor would we want to! However, getting from 0 to 1 is the hardest step. So we have made a few ways to get you up to speed and contributing in no time! 
 
-If you are looking for what is happening right now, add the [Optimism Public calender](https://calendar.google.com/calendar/embed?src=c_4hui70itm089e7t8q50heh1kno%40group.calendar.google.com) to see upcoming events! We also have a [“Get a Grant”](/grant/grant-overview) page if you already have an idea on how you want to contribute. 
+If you are looking for what is happening right now, add the [Optimism Public calendar](https://calendar.google.com/calendar/embed?src=c_4hui70itm089e7t8q50heh1kno%40group.calendar.google.com) to see upcoming events! We also have a [“Get a Grant”](/grant/grant-overview) page if you already have an idea on how you want to contribute. 
 
 ## 🌍 Accessibility
 


### PR DESCRIPTION
# Fix Typo in contribute-overview.mdx

## Description
This pull request corrects a typo in the `contribute-overview.mdx` file. The word "calender" has been updated to the correct spelling, "calendar," for improved clarity and professionalism.

### Changes:
- **Before**:  
  > add the [Optimism Public **calender**](https://calendar.google.com/...)  
- **After**:  
  > add the [Optimism Public **calendar**](https://calendar.google.com/...)

## Checklist
- [x] Correct the typo in the text.
- [x] Verify no additional instances of the typo exist in the file.

## Testing
No functional changes were made. Verified the text update for accuracy and alignment with the existing style.

---

Please let me know if further adjustments are needed!
