### PR TITLE
docs: Updated links for RetroPGF Rounds 1, 2, and 3

### DIFF
--- a/pages/citizens-house/how-retro-funding-works.mdx
+++ b/pages/citizens-house/how-retro-funding-works.mdx
@@ -43,6 +43,6 @@ Over time, the Collective aims to expand the scope of Retro Funding to support t
 
 # Past Rounds
 
-- [RetroPGF Round 3](/citizens-house/rounds/retropgf-3)
-- [RetroPGF Round 2](/citizens-house/rounds/retropgf-2)
-- [RetroPGF Round 1](/citizens-house/rounds/retropgf-1)
+- [RetroPGF Round 3](https://github.com/ethereum-optimism/community-hub/blob/main/pages/citizens-house/rounds/retropgf-3.mdx)
+- [RetroPGF Round 2](https://github.com/ethereum-optimism/community-hub/blob/main/pages/citizens-house/rounds/retropgf-2.mdx)
+- [RetroPGF Round 1](https://github.com/ethereum-optimism/community-hub/blob/main/pages/citizens-house/rounds/retropgf-1.mdx)


### PR DESCRIPTION
**Description**
Some of the links for RetroPGF Rounds 1, 2, and 3 were outdated or broken.
I’ve updated them to ensure they point to the correct and working resources. 