### PR TITLE
docs: Fix incorrect funding round reference in retropgf-5.mdx

### DIFF
--- a/pages/citizens-house/rounds/retropgf-5.mdx
+++ b/pages/citizens-house/rounds/retropgf-5.mdx
@@ -19,7 +19,7 @@ You can find a full overview of Retro Funding Round 5: OP Stack [here](https://g
 
 ## **Results**
 
-👉 You can view the [Retro Funding 5 Results page](https://retrofunding.optimism.io/round/results/5) [](https://retrofunding.optimism.io/round/results) announcing the Retro Funding Round 4 recipients, and explore the [results calculation](https://github.com/ethereum-optimism/op-analytics/tree/main/rpgf/rpgf5).
+👉 You can view the [Retro Funding 5 Results page](https://retrofunding.optimism.io/round/results/5) [](https://retrofunding.optimism.io/round/results) announcing the Retro Funding Round 5 recipients, and explore the [results calculation](https://github.com/ethereum-optimism/op-analytics/tree/main/rpgf/rpgf5).
 
 Retro Funding recipients must complete a KYC process with the Optimism Foundation. If you're a recipient, please direct questions or problems with the KYC & grant delivery process to retrofunding@optimism.io.
 


### PR DESCRIPTION
**Description**

<img width="948" alt="Снимок экрана 2025-02-01 в 10 30 41" src="https://github.com/user-attachments/assets/1daa0c64-7b68-4ffc-bf5c-2f56fe981ce8" />

I noticed a small but important inconsistency in the text. The mention of "Retro Funding Round 4" should actually refer to the fifth round, as the context clearly relates to Round 5. I’ve corrected this to avoid confusion.