### PR TITLE
docs: Added links to past RetroPGF Rounds 4, 5, and 6

### DIFF
--- a/pages/citizens-house/how-retro-funding-works.mdx
+++ b/pages/citizens-house/how-retro-funding-works.mdx
@@ -43,6 +43,9 @@ Over time, the Collective aims to expand the scope of Retro Funding to support t
 
 # Past Rounds
 
+- [RetroPGF Round 6](/citizens-house/rounds/retropgf-6)
+- [RetroPGF Round 5](/citizens-house/rounds/retropgf-5)
+- [RetroPGF Round 4](/citizens-house/rounds/retropgf-4)
 - [RetroPGF Round 3](/citizens-house/rounds/retropgf-3)
 - [RetroPGF Round 2](/citizens-house/rounds/retropgf-2)
 - [RetroPGF Round 1](/citizens-house/rounds/retropgf-1)


### PR DESCRIPTION
**Description**

Noticed that links to RetroPGF Rounds 4, 5, and 6 were missing, so I added them.

This should make it easier to navigate past rounds. 
