### PR TITLE
Retro Funding: link fixes

### DIFF
--- a/pages/citizens-house/rounds/retropgf-4.mdx
+++ b/pages/citizens-house/rounds/retropgf-4.mdx
@@ -17,7 +17,7 @@ You can find a full overview of Retro Funding Round 4: Onchain Builders [here](h
 - Results & Grant delivery: July 16th
 
 ## Results
-👉 You can view the [Retro Funding 4 Results page](https://atlas.optimism.io/round/results) announcing the Retro Funding Round 4 recipients, and explore the [results calculation](https://github.com/ethereum-optimism/op-analytics/tree/main/rpgf/rpgf4). 
+👉 You can view the [Retro Funding 4 Results page](https://atlas.optimism.io/round/results?rounds=4) announcing the Retro Funding Round 4 recipients, and explore the [results calculation](https://github.com/ethereum-optimism/op-analytics/tree/main/rpgf/rpgf4). 
 
 Retro Funding recipients must complete a KYC process with the Optimism Foundation. If you're a recipient, please direct questions or problems with the KYC & grant delivery process to retrofunding@optimism.io.
 
@@ -36,7 +36,7 @@ Badgeholders can find all the information relevant for voting in the [Badgeholde
 
 ## Project Applications
 
-👉 **Projects are able to apply for Retro Funding rounds via [retrofunding.optimism.io](https://retrofunding.optimism.io/)** 
+👉 **Projects are able to apply for Retro Funding rounds via [atlas.optimism.io](https://atlas.optimism.io/)** 
 
 All projects for Retro Funding Round 4 had to create an Optimist Profile, which serves as builder's persistent identity across the Collective. You can read more about this [here](https://gov.optimism.io/t/retro-funding-4-application-process/8013#sign-in-with-farcaster-4). 
 

--- a/pages/citizens-house/rounds/retropgf-5.mdx
+++ b/pages/citizens-house/rounds/retropgf-5.mdx
@@ -19,7 +19,7 @@ You can find a full overview of Retro Funding Round 5: OP Stack [here](https://g
 
 ## **Results**
 
-👉 You can view the [Retro Funding 5 Results page](https://retrofunding.optimism.io/round/results/5) [](https://retrofunding.optimism.io/round/results) announcing the Retro Funding Round 4 recipients, and explore the [results calculation](https://github.com/ethereum-optimism/op-analytics/tree/main/rpgf/rpgf5).
+👉 You can view the [Retro Funding 5 Results page](https://atlas.optimism.io/round/results?rounds=5) announcing the Retro Funding Round 5 recipients, and explore the [results calculation](https://github.com/ethereum-optimism/op-analytics/tree/main/rpgf/rpgf5).
 
 Retro Funding recipients must complete a KYC process with the Optimism Foundation. If you're a recipient, please direct questions or problems with the KYC & grant delivery process to retrofunding@optimism.io.
 

--- a/pages/citizens-house/rounds/retropgf-6.mdx
+++ b/pages/citizens-house/rounds/retropgf-6.mdx
@@ -19,7 +19,7 @@ You can find a full overview of Retro Funding Round 6: Governance [here](https:/
 
 ## **Results** 
 
-👉 You can view the Retro Funding results [here](https://retrofunding.optimism.io/round/results/6) and explore the results calculation [here](https://github.com/ethereum-optimism/op-analytics/tree/main/rpgf/rpgf6).
+👉 You can view the [Retro Funding 6 Results page](https://atlas.optimism.io/round/results?rounds=6) announcing the Retro Funding Round 6 recipients, and explore the [results calculation](https://github.com/ethereum-optimism/op-analytics/tree/main/rpgf/rpgf6).
 
 Retro Funding recipients must complete a KYC process with the Optimism Foundation. If you're a recipient, please direct questions or problems with the KYC & grant delivery process to retrofunding@optimism.io.
 


### PR DESCRIPTION
fixes broken links, replaces retrofunding.optimism.io with atlas.optimism.io